### PR TITLE
breaking: Introduce client-wide context.Context

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -1,11 +1,11 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
-
-	"fmt"
 
 	"github.com/hashicorp/errwrap"
 )
@@ -40,9 +40,13 @@ type Account struct {
 
 type GetAccountInput struct{}
 
-func (client *AccountsClient) GetAccount(input *GetAccountInput) (*Account, error) {
+func (client *AccountsClient) GetAccount(ctx context.Context, input *GetAccountInput) (*Account, error) {
+	if ctx == nil {
+		panic(nilContext)
+	}
+
 	path := fmt.Sprintf("/%s", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -75,8 +79,9 @@ type UpdateAccountInput struct {
 
 // UpdateAccount updates your account details with the given parameters.
 // TODO(jen20) Work out a safe way to test this
-func (client *AccountsClient) UpdateAccount(input *UpdateAccountInput) (*Account, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s", client.accountName), input)
+func (client *AccountsClient) UpdateAccount(ctx context.Context, input *UpdateAccountInput) (*Account, error) {
+	path := fmt.Sprintf("/%s", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"testing"
 )
 
@@ -10,7 +11,8 @@ func TestAccAccount_Get(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "account",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Accounts().GetAccount(&GetAccountInput{})
+					return client.Accounts().GetAccount(
+						context.Background(), &GetAccountInput{})
 				},
 			},
 			&StepAssertSet{

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,8 +28,9 @@ type Config struct {
 type GetConfigInput struct{}
 
 // GetConfig outputs configuration for your account.
-func (client *ConfigClient) GetConfig(input *GetConfigInput) (*Config, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/config", client.accountName), nil)
+func (client *ConfigClient) GetConfig(ctx context.Context, input *GetConfigInput) (*Config, error) {
+	path := fmt.Sprintf("/%s/config", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -51,9 +53,9 @@ type UpdateConfigInput struct {
 }
 
 // UpdateConfig updates configuration values for your account.
-// TODO(jen20) Work out a safe way to test this (after networks c implemented)
-func (client *ConfigClient) UpdateConfig(input *UpdateConfigInput) (*Config, error) {
-	respReader, err := client.executeRequest(http.MethodPut, fmt.Sprintf("/%s/config", client.accountName), input)
+func (client *ConfigClient) UpdateConfig(ctx context.Context, input *UpdateConfigInput) (*Config, error) {
+	path := fmt.Sprintf("/%s/config", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,9 @@
 package triton
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestAccConfig_Get(t *testing.T) {
 	AccTest(t, TestCase{
@@ -8,7 +11,8 @@ func TestAccConfig_Get(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "config",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Config().GetConfig(&GetConfigInput{})
+					return client.Config().GetConfig(
+						context.Background(), &GetConfigInput{})
 				},
 			},
 			&StepAssertSet{

--- a/datacenters.go
+++ b/datacenters.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -27,9 +28,9 @@ type DataCenter struct {
 
 type ListDataCentersInput struct{}
 
-func (client *DataCentersClient) ListDataCenters(*ListDataCentersInput) ([]*DataCenter, error) {
+func (client *DataCentersClient) ListDataCenters(ctx context.Context, _ *ListDataCentersInput) ([]*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -68,9 +69,9 @@ type GetDataCenterInput struct {
 	Name string
 }
 
-func (client *DataCentersClient) GetDataCenter(input *GetDataCenterInput) (*DataCenter, error) {
+func (client *DataCentersClient) GetDataCenter(ctx context.Context, input *GetDataCenterInput) (*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters/%s", client.accountName, input.Name)
-	resp, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	resp, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, errwrap.Wrapf("Error executing GetDatacenter request: {{err}}", err)
 	}

--- a/datacenters_test.go
+++ b/datacenters_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -18,9 +19,11 @@ func TestAccDataCenters_Get(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "datacenter",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Datacenters().GetDataCenter(&GetDataCenterInput{
-						Name: dataCenterName,
-					})
+					return client.Datacenters().GetDataCenter(
+						context.Background(),
+						&GetDataCenterInput{
+							Name: dataCenterName,
+						})
 				},
 			},
 			&StepAssert{
@@ -42,7 +45,9 @@ func TestAccDataCenters_List(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "datacenters",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Datacenters().ListDataCenters(&ListDataCentersInput{})
+					return client.Datacenters().ListDataCenters(
+						context.Background(),
+						&ListDataCentersInput{})
 				},
 			},
 			&StepAssertFunc{

--- a/fabrics.go
+++ b/fabrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -26,9 +27,9 @@ type FabricVLAN struct {
 
 type ListFabricVLANsInput struct{}
 
-func (client *FabricsClient) ListFabricVLANs(*ListFabricVLANsInput) ([]*FabricVLAN, error) {
+func (client *FabricsClient) ListFabricVLANs(ctx context.Context, _ *ListFabricVLANsInput) ([]*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -51,9 +52,9 @@ type CreateFabricVLANInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FabricsClient) CreateFabricVLAN(input *CreateFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) CreateFabricVLAN(ctx context.Context, input *CreateFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -76,9 +77,9 @@ type UpdateFabricVLANInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FabricsClient) UpdateFabricVLAN(input *UpdateFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) UpdateFabricVLAN(ctx context.Context, input *UpdateFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPut, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -99,9 +100,9 @@ type GetFabricVLANInput struct {
 	ID int `json:"-"`
 }
 
-func (client *FabricsClient) GetFabricVLAN(input *GetFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) GetFabricVLAN(ctx context.Context, input *GetFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -122,9 +123,9 @@ type DeleteFabricVLANInput struct {
 	ID int `json:"-"`
 }
 
-func (client *FabricsClient) DeleteFabricVLAN(input *DeleteFabricVLANInput) error {
+func (client *FabricsClient) DeleteFabricVLAN(ctx context.Context, input *DeleteFabricVLANInput) error {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -139,9 +140,9 @@ type ListFabricNetworksInput struct {
 	FabricVLANID int `json:"-"`
 }
 
-func (client *FabricsClient) ListFabricNetworks(input *ListFabricNetworksInput) ([]*Network, error) {
+func (client *FabricsClient) ListFabricNetworks(ctx context.Context, input *ListFabricNetworksInput) ([]*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks", client.accountName, input.FabricVLANID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -171,9 +172,9 @@ type CreateFabricNetworkInput struct {
 	InternetNAT      bool              `json:"internet_nat"`
 }
 
-func (client *FabricsClient) CreateFabricNetwork(input *CreateFabricNetworkInput) (*Network, error) {
+func (client *FabricsClient) CreateFabricNetwork(ctx context.Context, input *CreateFabricNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks", client.accountName, input.FabricVLANID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -195,9 +196,9 @@ type GetFabricNetworkInput struct {
 	NetworkID    string `json:"-"`
 }
 
-func (client *FabricsClient) GetFabricNetwork(input *GetFabricNetworkInput) (*Network, error) {
+func (client *FabricsClient) GetFabricNetwork(ctx context.Context, input *GetFabricNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks/%s", client.accountName, input.FabricVLANID, input.NetworkID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -219,9 +220,9 @@ type DeleteFabricNetworkInput struct {
 	NetworkID    string `json:"-"`
 }
 
-func (client *FabricsClient) DeleteFabricNetwork(input *DeleteFabricNetworkInput) error {
+func (client *FabricsClient) DeleteFabricNetwork(ctx context.Context, input *DeleteFabricNetworkInput) error {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks/%s", client.accountName, input.FabricVLANID, input.NetworkID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/firewall.go
+++ b/firewall.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,9 +39,9 @@ type FirewallRule struct {
 
 type ListFirewallRulesInput struct{}
 
-func (client *FirewallClient) ListFirewallRules(*ListFirewallRulesInput) ([]*FirewallRule, error) {
+func (client *FirewallClient) ListFirewallRules(ctx context.Context, _ *ListFirewallRulesInput) ([]*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/fwrules", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -61,9 +62,9 @@ type GetFirewallRuleInput struct {
 	ID string
 }
 
-func (client *FirewallClient) GetFirewallRule(input *GetFirewallRuleInput) (*FirewallRule, error) {
+func (client *FirewallClient) GetFirewallRule(ctx context.Context, input *GetFirewallRuleInput) (*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -86,8 +87,9 @@ type CreateFirewallRuleInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FirewallClient) CreateFirewallRule(input *CreateFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules", client.accountName), input)
+func (client *FirewallClient) CreateFirewallRule(ctx context.Context, input *CreateFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -111,8 +113,9 @@ type UpdateFirewallRuleInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FirewallClient) UpdateFirewallRule(input *UpdateFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID), input)
+func (client *FirewallClient) UpdateFirewallRule(ctx context.Context, input *UpdateFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -133,8 +136,9 @@ type EnableFirewallRuleInput struct {
 	ID string `json:"-"`
 }
 
-func (client *FirewallClient) EnableFirewallRule(input *EnableFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s/enable", client.accountName, input.ID), input)
+func (client *FirewallClient) EnableFirewallRule(ctx context.Context, input *EnableFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s/enable", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -155,8 +159,9 @@ type DisableFirewallRuleInput struct {
 	ID string `json:"-"`
 }
 
-func (client *FirewallClient) DisableFirewallRule(input *DisableFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s/disable", client.accountName, input.ID), input)
+func (client *FirewallClient) DisableFirewallRule(ctx context.Context, input *DisableFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s/disable", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -177,9 +182,9 @@ type DeleteFirewallRuleInput struct {
 	ID string
 }
 
-func (client *FirewallClient) DeleteFirewallRule(input *DeleteFirewallRuleInput) error {
+func (client *FirewallClient) DeleteFirewallRule(ctx context.Context, input *DeleteFirewallRuleInput) error {
 	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -194,9 +199,9 @@ type ListMachineFirewallRulesInput struct {
 	MachineID string
 }
 
-func (client *FirewallClient) ListMachineFirewallRules(input *ListMachineFirewallRulesInput) ([]*FirewallRule, error) {
+func (client *FirewallClient) ListMachineFirewallRules(ctx context.Context, input *ListMachineFirewallRulesInput) ([]*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/machines/%s/firewallrules", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/images.go
+++ b/images.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,9 +49,9 @@ type Image struct {
 
 type ListImagesInput struct{}
 
-func (client *ImagesClient) ListImages(*ListImagesInput) ([]*Image, error) {
+func (client *ImagesClient) ListImages(ctx context.Context, _ *ListImagesInput) ([]*Image, error) {
 	path := fmt.Sprintf("/%s/images", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -71,9 +72,9 @@ type GetImageInput struct {
 	ImageID string
 }
 
-func (client *ImagesClient) GetImage(input *GetImageInput) (*Image, error) {
+func (client *ImagesClient) GetImage(ctx context.Context, input *GetImageInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -94,9 +95,9 @@ type DeleteImageInput struct {
 	ImageID string
 }
 
-func (client *ImagesClient) DeleteImage(input *DeleteImageInput) error {
+func (client *ImagesClient) DeleteImage(ctx context.Context, input *DeleteImageInput) error {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -118,13 +119,13 @@ type MantaLocation struct {
 	ManifestPath string `json:"manifest_path"`
 }
 
-func (client *ImagesClient) ExportImage(input *ExportImageInput) (*MantaLocation, error) {
+func (client *ImagesClient) ExportImage(ctx context.Context, input *ExportImageInput) (*MantaLocation, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
 	query := &url.Values{}
 	query.Set("action", "export")
 	query.Set("manta_path", input.MantaPath)
 
-	respReader, err := client.executeRequestURIParams(http.MethodGet, path, nil, query)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodGet, path, nil, query)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -152,9 +153,9 @@ type CreateImageFromMachineInput struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-func (client *ImagesClient) CreateImageFromMachine(input *CreateImageFromMachineInput) (*Image, error) {
+func (client *ImagesClient) CreateImageFromMachine(ctx context.Context, input *CreateImageFromMachineInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -182,12 +183,12 @@ type UpdateImageInput struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-func (client *ImagesClient) UpdateImage(input *UpdateImageInput) (*Image, error) {
+func (client *ImagesClient) UpdateImage(ctx context.Context, input *UpdateImageInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
 	query := &url.Values{}
 	query.Set("action", "update")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, input, query)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, input, query)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/images_test.go
+++ b/images_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"context"
 	"github.com/abdullin/seq"
 	"time"
 )
@@ -17,7 +18,8 @@ func TestAccImagesList(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Images().ListImages(&ListImagesInput{})
+					return client.Images().ListImages(
+						context.Background(), &ListImagesInput{})
 				},
 			},
 			&StepAssertFunc{
@@ -69,18 +71,20 @@ func TestAccImagesList(t *testing.T) {
 func TestAccImagesGet(t *testing.T) {
 	const stateKey = "image"
 	const imageId = "95f6c9a6-a2bd-11e2-b753-dbf2651bf890"
-	publishedAt, err := time.Parse(time.RFC3339, "2013-04-11T21:05:28Z")
+	publishedAt, err := time.Parse(time.RFC3339, "2013-04-11T21:07:38Z")
 	if err != nil {
-		t.Fatalf("Reference time does not parse as RFC3339")
+		t.Fatal("Reference time does not parse as RFC3339")
 	}
 	AccTest(t, TestCase{
 		Steps: []Step{
 			&StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Images().GetImage(&GetImageInput{
-						ImageID: imageId,
-					})
+					return client.Images().GetImage(
+						context.Background(),
+						&GetImageInput{
+							ImageID: imageId,
+						})
 				},
 			},
 			&StepAssert{

--- a/keys.go
+++ b/keys.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,9 +35,9 @@ type ListKeysInput struct{}
 
 // ListKeys lists all public keys we have on record for the specified
 // account.
-func (client *KeysClient) ListKeys(*ListKeysInput) ([]*Key, error) {
-	path := fmt.Sprintf("/%s/keys")
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+func (client *KeysClient) ListKeys(ctx context.Context, _ *ListKeysInput) ([]*Key, error) {
+	path := fmt.Sprintf("/%s/keys", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -57,9 +58,9 @@ type GetKeyInput struct {
 	KeyName string
 }
 
-func (client *KeysClient) GetKey(input *GetKeyInput) (*Key, error) {
+func (client *KeysClient) GetKey(ctx context.Context, input *GetKeyInput) (*Key, error) {
 	path := fmt.Sprintf("/%s/keys/%s", client.accountName, input.KeyName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -80,9 +81,9 @@ type DeleteKeyInput struct {
 	KeyName string
 }
 
-func (client *KeysClient) DeleteKey(input *DeleteKeyInput) error {
+func (client *KeysClient) DeleteKey(ctx context.Context, input *DeleteKeyInput) error {
 	path := fmt.Sprintf("/%s/keys/%s", client.accountName, input.KeyName)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -104,8 +105,9 @@ type CreateKeyInput struct {
 }
 
 // CreateKey uploads a new OpenSSH key to Triton for use in HTTP signing and SSH.
-func (client *KeysClient) CreateKey(input *CreateKeyInput) (*Key, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/keys", client.accountName), input)
+func (client *KeysClient) CreateKey(ctx context.Context, input *CreateKeyInput) (*Key, error) {
+	path := fmt.Sprintf("/%s/keys", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,8 +1,10 @@
 package triton
 
 import (
-	"github.com/abdullin/seq"
+	"context"
 	"testing"
+
+	"github.com/abdullin/seq"
 )
 
 func TestAccKey_Create(t *testing.T) {
@@ -13,13 +15,19 @@ func TestAccKey_Create(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "key",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Keys().CreateKey(&CreateKeyInput{
-						Name: keyName,
-						Key:  testAccCreateKeyMaterial,
-					})
+					return client.Keys().CreateKey(
+						context.Background(),
+						&CreateKeyInput{
+							Name: keyName,
+							Key:  testAccCreateKeyMaterial,
+						})
 				},
 				CleanupFunc: func(client *Client, callState interface{}) {
-					client.Keys().DeleteKey(&DeleteKeyInput{KeyName: keyName})
+					client.Keys().DeleteKey(
+						context.Background(),
+						&DeleteKeyInput{
+							KeyName: keyName,
+						})
 				},
 			},
 			&StepAssert{
@@ -42,19 +50,28 @@ func TestAccKey_Get(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "key",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Keys().CreateKey(&CreateKeyInput{
-						Name: keyName,
-						Key:  testAccCreateKeyMaterial,
-					})
+					return client.Keys().CreateKey(
+						context.Background(),
+						&CreateKeyInput{
+							Name: keyName,
+							Key:  testAccCreateKeyMaterial,
+						})
 				},
 				CleanupFunc: func(client *Client, callState interface{}) {
-					client.Keys().DeleteKey(&DeleteKeyInput{KeyName: keyName})
+					client.Keys().DeleteKey(
+						context.Background(),
+						&DeleteKeyInput{
+							KeyName: keyName,
+						})
 				},
 			},
 			&StepAPICall{
 				StateBagKey: "getKey",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Keys().GetKey(&GetKeyInput{KeyName: keyName})
+					return client.Keys().GetKey(context.Background(),
+						&GetKeyInput{
+							KeyName: keyName,
+						})
 				},
 			},
 			&StepAssert{
@@ -77,25 +94,39 @@ func TestAccKey_Delete(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "key",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Keys().CreateKey(&CreateKeyInput{
-						Name: keyName,
-						Key:  testAccCreateKeyMaterial,
-					})
+					return client.Keys().CreateKey(
+						context.Background(),
+						&CreateKeyInput{
+							Name: keyName,
+							Key:  testAccCreateKeyMaterial,
+						})
 				},
 				CleanupFunc: func(client *Client, callState interface{}) {
-					client.Keys().DeleteKey(&DeleteKeyInput{KeyName: keyName})
+					client.Keys().DeleteKey(
+						context.Background(),
+						&DeleteKeyInput{
+							KeyName: keyName,
+						})
 				},
 			},
 			&StepAPICall{
 				StateBagKey: "noop",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return nil, client.Keys().DeleteKey(&DeleteKeyInput{KeyName: keyName})
+					return nil, client.Keys().DeleteKey(
+						context.Background(),
+						&DeleteKeyInput{
+							KeyName: keyName,
+						})
 				},
 			},
 			&StepAPICall{
 				ErrorKey: "getKeyError",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Keys().GetKey(&GetKeyInput{KeyName: keyName})
+					return client.Keys().GetKey(
+						context.Background(),
+						&GetKeyInput{
+							KeyName: keyName,
+						})
 				},
 			},
 			&StepAssertTritonError{

--- a/machines.go
+++ b/machines.go
@@ -1,13 +1,13 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
-
-	"net/url"
 
 	"github.com/hashicorp/errwrap"
 )
@@ -62,7 +62,7 @@ type Machine struct {
 }
 
 // _Machine is a private facade over Machine that handles the necessary API
-// overrides from vmapi's machine endpoint(s).
+// overrides from VMAPI's machine endpoint(s).
 type _Machine struct {
 	Machine
 	Tags map[string]interface{} `json:"tags"`
@@ -90,13 +90,13 @@ func (gmi *GetMachineInput) Validate() error {
 	return nil
 }
 
-func (client *MachinesClient) GetMachine(input *GetMachineInput) (*Machine, error) {
+func (client *MachinesClient) GetMachine(ctx context.Context, input *GetMachineInput) (*Machine, error) {
 	if err := input.Validate(); err != nil {
 		return nil, errwrap.Wrapf("unable to get machine: {{err}}", err)
 	}
 
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
-	response, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if response != nil {
 		defer response.Body.Close()
 	}
@@ -124,9 +124,11 @@ func (client *MachinesClient) GetMachine(input *GetMachineInput) (*Machine, erro
 	return native, nil
 }
 
-func (client *MachinesClient) GetMachines() ([]*Machine, error) {
+type ListMachinesInput struct{}
+
+func (client *MachinesClient) ListMachines(ctx context.Context, _ *ListMachinesInput) ([]*Machine, error) {
 	path := fmt.Sprintf("/%s/machines", client.accountName)
-	response, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if response != nil {
 		defer response.Body.Close()
 	}
@@ -136,14 +138,14 @@ func (client *MachinesClient) GetMachines() ([]*Machine, error) {
 		}
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing GetMachines request: {{err}}",
+		return nil, errwrap.Wrapf("Error executing ListMachines request: {{err}}",
 			client.decodeError(response.StatusCode, response.Body))
 	}
 
 	var results []*_Machine
 	decoder := json.NewDecoder(response.Body)
 	if err = decoder.Decode(&results); err != nil {
-		return nil, errwrap.Wrapf("Error decoding GetMachines response: {{err}}", err)
+		return nil, errwrap.Wrapf("Error decoding ListMachines response: {{err}}", err)
 	}
 
 	machines := make([]*Machine, 0, len(results))
@@ -218,9 +220,9 @@ func (input *CreateMachineInput) toAPI() map[string]interface{} {
 	return result
 }
 
-func (client *MachinesClient) CreateMachine(input *CreateMachineInput) (*Machine, error) {
+func (client *MachinesClient) CreateMachine(ctx context.Context, input *CreateMachineInput) (*Machine, error) {
 	path := fmt.Sprintf("/%s/machines", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input.toAPI())
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input.toAPI())
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -241,9 +243,9 @@ type DeleteMachineInput struct {
 	ID string
 }
 
-func (client *MachinesClient) DeleteMachine(input *DeleteMachineInput) error {
+func (client *MachinesClient) DeleteMachine(ctx context.Context, input *DeleteMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
-	response, err := client.executeRequestRaw(http.MethodDelete, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodDelete, path, nil)
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -262,9 +264,9 @@ type DeleteMachineTagsInput struct {
 	ID string
 }
 
-func (client *MachinesClient) DeleteMachineTags(input *DeleteMachineTagsInput) error {
+func (client *MachinesClient) DeleteMachineTags(ctx context.Context, input *DeleteMachineTagsInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	response, err := client.executeRequestRaw(http.MethodDelete, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodDelete, path, nil)
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -284,9 +286,9 @@ type DeleteMachineTagInput struct {
 	Key string
 }
 
-func (client *MachinesClient) DeleteMachineTag(input *DeleteMachineTagInput) error {
+func (client *MachinesClient) DeleteMachineTag(ctx context.Context, input *DeleteMachineTagInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags/%s", client.accountName, input.ID, input.Key)
-	response, err := client.executeRequestRaw(http.MethodDelete, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodDelete, path, nil)
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -306,14 +308,14 @@ type RenameMachineInput struct {
 	Name string
 }
 
-func (client *MachinesClient) RenameMachine(input *RenameMachineInput) error {
+func (client *MachinesClient) RenameMachine(ctx context.Context, input *RenameMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "rename")
 	params.Set("name", input.Name)
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -329,9 +331,9 @@ type ReplaceMachineTagsInput struct {
 	Tags map[string]string
 }
 
-func (client *MachinesClient) ReplaceMachineTags(input *ReplaceMachineTagsInput) error {
+func (client *MachinesClient) ReplaceMachineTags(ctx context.Context, input *ReplaceMachineTagsInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPut, path, input.Tags)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input.Tags)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -347,9 +349,9 @@ type AddMachineTagsInput struct {
 	Tags map[string]string
 }
 
-func (client *MachinesClient) AddMachineTags(input *AddMachineTagsInput) error {
+func (client *MachinesClient) AddMachineTags(ctx context.Context, input *AddMachineTagsInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input.Tags)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input.Tags)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -365,9 +367,9 @@ type GetMachineTagInput struct {
 	Key string
 }
 
-func (client *MachinesClient) GetMachineTag(input *GetMachineTagInput) (string, error) {
+func (client *MachinesClient) GetMachineTag(ctx context.Context, input *GetMachineTagInput) (string, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags/%s", client.accountName, input.ID, input.Key)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -388,9 +390,9 @@ type ListMachineTagsInput struct {
 	ID string
 }
 
-func (client *MachinesClient) ListMachineTags(input *ListMachineTagsInput) (map[string]string, error) {
+func (client *MachinesClient) ListMachineTags(ctx context.Context, input *ListMachineTagsInput) (map[string]string, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -413,9 +415,9 @@ type UpdateMachineMetadataInput struct {
 	Metadata map[string]string
 }
 
-func (client *MachinesClient) UpdateMachineMetadata(input *UpdateMachineMetadataInput) (map[string]string, error) {
+func (client *MachinesClient) UpdateMachineMetadata(ctx context.Context, input *UpdateMachineMetadataInput) (map[string]string, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input.Metadata)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input.Metadata)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -437,14 +439,14 @@ type ResizeMachineInput struct {
 	Package string
 }
 
-func (client *MachinesClient) ResizeMachine(input *ResizeMachineInput) error {
+func (client *MachinesClient) ResizeMachine(ctx context.Context, input *ResizeMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "resize")
 	params.Set("package", input.Package)
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -459,13 +461,13 @@ type EnableMachineFirewallInput struct {
 	ID string
 }
 
-func (client *MachinesClient) EnableMachineFirewall(input *EnableMachineFirewallInput) error {
+func (client *MachinesClient) EnableMachineFirewall(ctx context.Context, input *EnableMachineFirewallInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "enable_firewall")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -480,13 +482,13 @@ type DisableMachineFirewallInput struct {
 	ID string
 }
 
-func (client *MachinesClient) DisableMachineFirewall(input *DisableMachineFirewallInput) error {
+func (client *MachinesClient) DisableMachineFirewall(ctx context.Context, input *DisableMachineFirewallInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "disable_firewall")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -501,9 +503,9 @@ type ListNICsInput struct {
 	MachineID string
 }
 
-func (client *MachinesClient) ListNICs(input *ListNICsInput) ([]*NIC, error) {
+func (client *MachinesClient) ListNICs(ctx context.Context, input *ListNICsInput) ([]*NIC, error) {
 	path := fmt.Sprintf("/%s/machines/%s/nics", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -525,9 +527,9 @@ type AddNICInput struct {
 	Network   string `json:"network"`
 }
 
-func (client *MachinesClient) AddNIC(input *AddNICInput) (*NIC, error) {
+func (client *MachinesClient) AddNIC(ctx context.Context, input *AddNICInput) (*NIC, error) {
 	path := fmt.Sprintf("/%s/machines/%s/nics", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -549,9 +551,9 @@ type RemoveNICInput struct {
 	MAC       string
 }
 
-func (client *MachinesClient) RemoveNIC(input *RemoveNICInput) error {
+func (client *MachinesClient) RemoveNIC(ctx context.Context, input *RemoveNICInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/nics/%s", client.accountName, input.MachineID, input.MAC)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -566,13 +568,13 @@ type StopMachineInput struct {
 	MachineID string
 }
 
-func (client *MachinesClient) StopMachine(input *StopMachineInput) error {
+func (client *MachinesClient) StopMachine(ctx context.Context, input *StopMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.MachineID)
 
 	params := &url.Values{}
 	params.Set("action", "stop")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -587,13 +589,13 @@ type StartMachineInput struct {
 	MachineID string
 }
 
-func (client *MachinesClient) StartMachine(input *StartMachineInput) error {
+func (client *MachinesClient) StartMachine(ctx context.Context, input *StartMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.MachineID)
 
 	params := &url.Values{}
 	params.Set("action", "start")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/machines_test.go
+++ b/machines_test.go
@@ -1,14 +1,19 @@
 package triton_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	triton "github.com/joyent/triton-go"
+	"github.com/joyent/triton-go"
 )
 
 func getAnyMachineID(t *testing.T, c *triton.Client) (string, error) {
-	machines, err := c.Machines().GetMachines()
+	machines, err := c.Machines().ListMachines(
+		context.Background(),
+		&triton.ListMachinesInput{},
+	)
 	if err != nil {
 		return "", err
 	}
@@ -20,7 +25,7 @@ func getAnyMachineID(t *testing.T, c *triton.Client) (string, error) {
 	}
 
 	t.Skip()
-	return "", fmt.Errorf("no machines configured")
+	return "", errors.New("no machines configured")
 }
 
 func TestAccMachine_GetMachine(t *testing.T) {
@@ -34,9 +39,11 @@ func TestAccMachine_GetMachine(t *testing.T) {
 						return nil, err
 					}
 
-					return client.Machines().GetMachine(&triton.GetMachineInput{
-						ID: machineID,
-					})
+					return client.Machines().GetMachine(
+						context.Background(),
+						&triton.GetMachineInput{
+							ID: machineID,
+						})
 				},
 			},
 			&triton.StepAssertSet{
@@ -60,9 +67,11 @@ func TestAccMachine_ListMachineTags(t *testing.T) {
 						return nil, err
 					}
 
-					return client.Machines().ListMachineTags(&triton.ListMachineTagsInput{
-						ID: machineID,
-					})
+					return client.Machines().ListMachineTags(
+						context.Background(),
+						&triton.ListMachineTagsInput{
+							ID: machineID,
+						})
 				},
 			},
 			&triton.StepAssertFunc{
@@ -74,7 +83,7 @@ func TestAccMachine_ListMachineTags(t *testing.T) {
 
 					tags := tagsRaw.(map[string]string)
 					if len(tags) == 0 {
-						return fmt.Errorf("Expected at least one tag on machine")
+						return errors.New("Expected at least one tag on machine")
 					}
 					return nil
 				},

--- a/networks.go
+++ b/networks.go
@@ -2,9 +2,10 @@ package triton
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	"fmt"
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -35,9 +36,9 @@ type Network struct {
 
 type ListNetworksInput struct{}
 
-func (client *NetworksClient) ListNetworks(*ListNetworksInput) ([]*Network, error) {
+func (client *NetworksClient) ListNetworks(ctx context.Context, _ *ListNetworksInput) ([]*Network, error) {
 	path := fmt.Sprintf("/%s/networks", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -58,9 +59,9 @@ type GetNetworkInput struct {
 	ID string
 }
 
-func (client *NetworksClient) GetNetwork(input *GetNetworkInput) (*Network, error) {
+func (client *NetworksClient) GetNetwork(ctx context.Context, input *GetNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/networks/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/networks_test.go
+++ b/networks_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -13,7 +14,9 @@ func TestAccNetworks_List(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: "networks",
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Networks().ListNetworks(&ListNetworksInput{})
+					return client.Networks().ListNetworks(
+						context.Background(),
+						&ListNetworksInput{})
 				},
 			},
 			&StepAssertFunc{

--- a/packages.go
+++ b/packages.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -43,8 +44,9 @@ type ListPackagesInput struct {
 	Group   string `json:"group"`
 }
 
-func (client *PackagesClient) ListPackages(input *ListPackagesInput) ([]*Package, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/packages", client.accountName), input)
+func (client *PackagesClient) ListPackages(ctx context.Context, input *ListPackagesInput) ([]*Package, error) {
+	path := fmt.Sprintf("/%s/packages", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -65,9 +67,9 @@ type GetPackageInput struct {
 	ID string
 }
 
-func (client *PackagesClient) GetPackage(input *GetPackageInput) (*Package, error) {
+func (client *PackagesClient) GetPackage(ctx context.Context, input *GetPackageInput) (*Package, error) {
 	path := fmt.Sprintf("/%s/packages/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/random_test.go
+++ b/random_test.go
@@ -11,9 +11,6 @@ func init() {
 	seed.Init()
 }
 
-// Helpers for generating random tidbits for use in identifiers to prevent
-// collisions in acceptance tests.
-
 // RandString generates a random alphanumeric string of the length specified
 func RandString(strlen int) string {
 	return RandStringFromCharSet(strlen, CharSetAlphaNum)

--- a/roles.go
+++ b/roles.go
@@ -1,10 +1,12 @@
 package triton
 
 import (
-	"fmt"
-	"github.com/hashicorp/errwrap"
-	"net/http"
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/errwrap"
 )
 
 type RolesClient struct {
@@ -27,8 +29,9 @@ type Role struct {
 
 type ListRolesInput struct{}
 
-func (client *RolesClient) ListRoles(*ListRolesInput) ([]*Role, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/roles", client.accountName), nil)
+func (client *RolesClient) ListRoles(ctx context.Context, _ *ListRolesInput) ([]*Role, error) {
+	path := fmt.Sprintf("/%s/roles", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -45,13 +48,13 @@ func (client *RolesClient) ListRoles(*ListRolesInput) ([]*Role, error) {
 	return result, nil
 }
 
-type GetRoleInput struct{
+type GetRoleInput struct {
 	RoleID string
 }
 
-func (client *RolesClient) GetRole(input *GetRoleInput) (*Role, error) {
+func (client *RolesClient) GetRole(ctx context.Context, input *GetRoleInput) (*Role, error) {
 	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -85,8 +88,9 @@ type CreateRoleInput struct {
 	DefaultMembers []string `json:"default_members,omitempty"`
 }
 
-func (client *RolesClient) CreateRole(input *CreateRoleInput) (*Role, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/roles", client.accountName), input)
+func (client *RolesClient) CreateRole(ctx context.Context, input *CreateRoleInput) (*Role, error) {
+	path := fmt.Sprintf("/%s/roles", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -123,8 +127,9 @@ type UpdateRoleInput struct {
 	DefaultMembers []string `json:"default_members,omitempty"`
 }
 
-func (client *RolesClient) UpdateRole(input *UpdateRoleInput) (*Role, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID), input)
+func (client *RolesClient) UpdateRole(ctx context.Context, input *UpdateRoleInput) (*Role, error) {
+	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -145,9 +150,9 @@ type DeleteRoleInput struct {
 	RoleID string
 }
 
-func (client *RolesClient) DeleteRoles(input *DeleteRoleInput) error {
+func (client *RolesClient) DeleteRoles(ctx context.Context, input *DeleteRoleInput) error {
 	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/services.go
+++ b/services.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,8 +27,9 @@ type Service struct {
 
 type ListServicesInput struct{}
 
-func (client *ServicesClient) ListServices(*ListServicesInput) ([]*Service, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/services", client.accountName), nil)
+func (client *ServicesClient) ListServices(ctx context.Context, _ *ListServicesInput) ([]*Service, error) {
+	path := fmt.Sprintf("/%s/services", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/services_test.go
+++ b/services_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -13,7 +14,9 @@ func TestAccServicesList(t *testing.T) {
 			&StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client *Client) (interface{}, error) {
-					return client.Services().ListServices(&ListServicesInput{})
+					return client.Services().ListServices(
+						context.Background(),
+						&ListServicesInput{})
 				},
 			},
 			&StepAssertFunc{

--- a/steps_test.go
+++ b/steps_test.go
@@ -42,7 +42,7 @@ func (s *StepAPICall) Cleanup(state TritonStateBag) {
 	if callState, ok := state.GetOk(s.StateBagKey); ok {
 		s.CleanupFunc(state.Client(), callState)
 	} else {
-		log.Printf("[INFO] No state for API call, calling cleanup with nil call state")
+		log.Print("[INFO] No state for API call, calling cleanup with nil call state")
 		s.CleanupFunc(state.Client(), nil)
 	}
 }


### PR DESCRIPTION
This commit makes every method to every Triton client take a context in order that the consumer can set deadlines, timeouts and so forth. This also mandates the removal of the RetryableHTTP library in favour of the standard library HTTP client (without upstreaming changes to RetryableHTTP).

This is a breaking change, however it is a vast improvement and worth taking the hit sooner rather than later.

We also clean up various nits - format strings without formatting values and so forth.