### PR TITLE
Always return the `StatusCode` when returning an error.

### DIFF
--- a/machines.go
+++ b/machines.go
@@ -102,7 +102,8 @@ func (client *MachinesClient) GetMachine(ctx context.Context, input *GetMachineI
 	}
 	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil, &TritonError{
-			Code: "ResourceNotFound",
+			StatusCode: http.StatusCode,
+			Code:       "ResourceNotFound",
 		}
 	}
 	if err != nil {
@@ -134,7 +135,8 @@ func (client *MachinesClient) ListMachines(ctx context.Context, _ *ListMachinesI
 	}
 	if response.StatusCode == http.StatusNotFound {
 		return nil, &TritonError{
-			Code: "ResourceNotFound",
+			StatusCode: http.StatusCode,
+			Code:       "ResourceNotFound",
 		}
 	}
 	if err != nil {
@@ -249,7 +251,7 @@ func (client *MachinesClient) DeleteMachine(ctx context.Context, input *DeleteMa
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	if response.StatusCode == http.StatusNotFound {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
This is required to detect that machines have in fact been fully removed when deleting an image by Packer.  Follow up PR to packer relying on this change required.