### PR TITLE
Improve machine *NIC() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ PASS
 ok  	github.com/jen20/triton-go	31.861s
 ```
 
-[4]: https://github.com/joyent/node-http-signature/blob/master/http_signing.md 
+[4]: https://github.com/joyent/node-http-signature/blob/master/http_signing.md
 [5]: https://godoc.org/github.com/joyent/go-triton/authentication
 [6]: https://godoc.org/github.com/joyent/go-triton/authentication
 [7]: https://github.com/hashicorp/go-errwrap

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The following list is updated as new functionality is added. The complete list o
 	- [x] ListNetworks
 	- [x] GetNetwork
 - Nics
-	- [ ] ListNics
+	- [X] ListNics
 	- [X] GetNic
 	- [x] AddNic
 	- [x] RemoveNic

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The following list is updated as new functionality is added. The complete list o
 	- [x] GetNetwork
 - Nics
 	- [ ] ListNics
-	- [ ] GetNic
+	- [X] GetNic
 	- [x] AddNic
 	- [x] RemoveNic
 

--- a/errors.go
+++ b/errors.go
@@ -93,6 +93,11 @@ func IsRequestMoved(err error) bool {
 	return isSpecificError(err, "RequestMoved")
 }
 
+// IsResourceFound tests whether err wraps a TritonError with code ResourceFound
+func IsResourceFound(err error) bool {
+	return isSpecificError(err, "ResourceFound")
+}
+
 // IsResourceNotFound tests whether err wraps a TritonError with
 // code ResourceNotFound
 func IsResourceNotFound(err error) bool {

--- a/machines.go
+++ b/machines.go
@@ -554,7 +554,7 @@ type RemoveNICInput struct {
 }
 
 func (client *MachinesClient) RemoveNIC(ctx context.Context, input *RemoveNICInput) error {
-	path := fmt.Sprintf("/%s/machines/%s/nics/%s", client.accountName, input.MachineID, input.MAC)
+	path := fmt.Sprintf("/%s/machines/%s/nics/%s", client.accountName, input.MachineID, strings.Replace(input.MAC, ":", "", -1))
 	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()

--- a/machines.go
+++ b/machines.go
@@ -561,10 +561,11 @@ type AddNICInput struct {
 	Network   string `json:"network"`
 }
 
-// AddNIC adds a NIC to a given machine.  AddNIC() will restart the given
-// instance.  Only one NIC per network may exist.  If a NIC for a given network
-// already exists, a ResourceFound error will be returned.  A NIC is running
-// when GetNIC()'s NIC.state is set to "running".
+// AddNIC asynchronously adds a NIC to a given machine.  If a NIC for a given
+// network already exists, a ResourceFound error will be returned.  The status
+// of the addition of a NIC can be polled by calling GetNIC()'s and testing NIC
+// until its state is set to "running".  Only one NIC per network may exist.
+// Warning: this operation causes the machine to restart.
 func (client *MachinesClient) AddNIC(ctx context.Context, input *AddNICInput) (*NIC, error) {
 	path := fmt.Sprintf("/%s/machines/%s/nics", client.accountName, input.MachineID)
 	response, err := client.executeRequestRaw(ctx, http.MethodPost, path, input)


### PR DESCRIPTION
Expanded the scope of this PR to include:

* Added `GetNIC()` support
* improvements to both `AddNIC()`, and `RemoveNIC()`.

In `RemoveNIC()`: MAC addresses arg in `RemoveNIC()` can not include `:` between hex nibbles.  Strep them out before making the API call.  TL;DR: CloudAPI returns colon delimited nibbles, however `RemoveNIC()` does not permit colons when round-tripping the data.

Related docs: 
* https://apidocs.joyent.com/cloudapi/#RemoveNic
* https://apidocs.joyent.com/cloudapi/#GetNic
* https://apidocs.joyent.com/cloudapi/#AddNic