### PR TITLE
Remove dependency on hashicorp/errwrap

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/joyent/triton-go/authentication"
 )
 
@@ -34,7 +33,7 @@ type Client struct {
 func NewClient(endpoint string, accountName string, signers ...authentication.Signer) (*Client, error) {
 	apiURL, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, errwrap.Wrapf("invalid endpoint: {{err}}", err)
+		return nil, WrapErrorf("invalid endpoint: {{err}}", err)
 	}
 
 	if accountName == "" {
@@ -104,7 +103,7 @@ func (c *Client) executeRequestURIParams(ctx context.Context, method, path strin
 
 	req, err := http.NewRequest(method, endpoint.String(), requestBody)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error constructing HTTP request: {{err}}", err)
+		return nil, WrapErrorf("Error constructing HTTP request: {{err}}", err)
 	}
 
 	dateHeader := time.Now().UTC().Format(time.RFC1123)
@@ -112,7 +111,7 @@ func (c *Client) executeRequestURIParams(ctx context.Context, method, path strin
 
 	authHeader, err := c.authorizer[0].Sign(dateHeader)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error signing HTTP request: {{err}}", err)
+		return nil, WrapErrorf("Error signing HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Accept", "application/json")
@@ -125,7 +124,7 @@ func (c *Client) executeRequestURIParams(ctx context.Context, method, path strin
 
 	resp, err := c.client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing HTTP request: {{err}}", err)
+		return nil, WrapErrorf("Error executing HTTP request: {{err}}", err)
 	}
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
@@ -142,7 +141,7 @@ func (c *Client) decodeError(statusCode int, body io.Reader) error {
 
 	errorDecoder := json.NewDecoder(body)
 	if err := errorDecoder.Decode(err); err != nil {
-		return errwrap.Wrapf("Error decoding error response: {{err}}", err)
+		return WrapErrorf("Error decoding error response: {{err}}", err)
 	}
 
 	return err
@@ -167,7 +166,7 @@ func (c *Client) executeRequestRaw(ctx context.Context, method, path string, bod
 
 	req, err := http.NewRequest(method, endpoint.String(), requestBody)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error constructing HTTP request: {{err}}", err)
+		return nil, WrapErrorf("Error constructing HTTP request: {{err}}", err)
 	}
 
 	dateHeader := time.Now().UTC().Format(time.RFC1123)
@@ -175,7 +174,7 @@ func (c *Client) executeRequestRaw(ctx context.Context, method, path string, bod
 
 	authHeader, err := c.authorizer[0].Sign(dateHeader)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error signing HTTP request: {{err}}", err)
+		return nil, WrapErrorf("Error signing HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Accept", "application/json")
@@ -188,7 +187,7 @@ func (c *Client) executeRequestRaw(ctx context.Context, method, path string, bod
 
 	resp, err := c.client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing HTTP request: {{err}}", err)
+		return nil, WrapErrorf("Error executing HTTP request: {{err}}", err)
 	}
 
 	return resp, nil

--- a/errwrap.go
+++ b/errwrap.go
@@ -1,0 +1,56 @@
+package triton
+
+import (
+	"errors"
+	"strings"
+)
+
+// wrappedError is an implementation of error that has both the
+// outer and inner errors.
+type wrappedError struct {
+	Outer error
+	Inner error
+}
+
+// Error returns our outer error as a string by proxying straight to the outer
+// object's own Error function.
+func (w *wrappedError) Error() string {
+	return w.Outer.Error()
+}
+
+// WrappedErrors returns an array of wrapped errors set on our wrappedError
+// object.
+func (w *wrappedError) WrappedErrors() []error {
+	return []error{w.Outer, w.Inner}
+}
+
+// WrapError defines that outer wraps inner, returning an error type that can be
+// cleanly used with the other methods in this package, such as Contains,
+// GetAll, etc.
+//
+// This function won't modify the error message at all (the outer message will
+// be used).
+func WrapError(outer, inner error) error {
+	return &wrappedError{
+		Outer: outer,
+		Inner: inner,
+	}
+}
+
+// WrapErrorf wraps an error with a formatting message. This is similar to using
+// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap errors,
+// you should replace it with this.
+//
+// format is the format of the error message. The string '{{err}}' will be
+// replaced with the original error message.
+func WrapErrorf(format string, err error) error {
+	outerMsg := "<nil>"
+	if err != nil {
+		outerMsg = err.Error()
+	}
+
+	outer := errors.New(strings.Replace(
+		format, "{{err}}", outerMsg, -1))
+
+	return WrapError(outer, err)
+}


### PR DESCRIPTION
This PR addresses #10 by fork lifting the functionality while still removing the dependency. Our primary use case should still be addressed by including the error wrapping functionality internally to `triton-go`.

Looking for feedback before I continue down the route of replacing every other case throughout our API.

/cc @jen20 @sean- @tgross 