### PR TITLE
Patch NPE by constructing a default SSHAgentSigner under NewClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,6 +19,8 @@ import (
 
 const nilContext = "nil context"
 
+var MissingKeyIdError = errors.New("Default SSH agent authentication requires SDC_KEY_ID")
+
 // Client represents a connection to the Triton API.
 type Client struct {
 	client      *http.Client
@@ -73,7 +75,7 @@ func NewClient(endpoint string, accountName string, signers ...authentication.Si
 			}
 			newClient.authorizers = append(authorizers, keySigner)
 		} else {
-			return nil, errors.New("Default SSH agent authentication requires SDC_KEY_ID!")
+			return nil, MissingKeyIdError
 		}
 	}
 


### PR DESCRIPTION
This PR addresses an edge case where a user can cause a self inflicted NPE ([here](https://github.com/joyent/triton-go/blob/master/client.go#L113) and [here](https://github.com/joyent/triton-go/blob/master/client.go#L176)) by not constructing a proper client without passing in an `authentication.Signer`. 

I've added a little more error handling and a new default behavior which utilizes `SSHAgentSigner` if an `SDC_KEY_ID` is found in the user's environment. Also, I believe this is how other HTTP clients act that I've used in the past.