### PR TITLE
Handle `sdc_docker` tag and it's bool value

### DIFF
--- a/machines.go
+++ b/machines.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ const (
 	machineCNSTagDisable    = "triton.cns.disable"
 	machineCNSTagReversePTR = "triton.cns.reverse_ptr"
 	machineCNSTagServices   = "triton.cns.services"
+	machineSDCDocker        = "sdc_docker"
 )
 
 // MachineCNS is a container for the CNS-specific attributes.  In the API these
@@ -669,6 +671,7 @@ var reservedMachineCNSTags = map[string]struct{}{
 	machineCNSTagDisable:    {},
 	machineCNSTagReversePTR: {},
 	machineCNSTagServices:   {},
+	machineSDCDocker:        {},
 }
 
 // machineTagsExtractMeta() extracts all of the misc parameters from Tags and
@@ -679,6 +682,8 @@ func machineTagsExtractMeta(tags map[string]interface{}) (MachineCNS, map[string
 	for k, raw := range tags {
 		if _, found := reservedMachineCNSTags[k]; found {
 			switch k {
+			case machineSDCDocker:
+				nativeTags[k] = strconv.FormatBool(raw.(bool))
 			case machineCNSTagDisable:
 				b := raw.(bool)
 				nativeCNS.Disable = &b

--- a/machines.go
+++ b/machines.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,7 +26,6 @@ const (
 	machineCNSTagDisable    = "triton.cns.disable"
 	machineCNSTagReversePTR = "triton.cns.reverse_ptr"
 	machineCNSTagServices   = "triton.cns.services"
-	machineSDCDocker        = "sdc_docker"
 )
 
 // MachineCNS is a container for the CNS-specific attributes.  In the API these
@@ -40,26 +38,26 @@ type MachineCNS struct {
 }
 
 type Machine struct {
-	ID              string            `json:"id"`
-	Name            string            `json:"name"`
-	Type            string            `json:"type"`
-	Brand           string            `json:"brand"`
-	State           string            `json:"state"`
-	Image           string            `json:"image"`
-	Memory          int               `json:"memory"`
-	Disk            int               `json:"disk"`
-	Metadata        map[string]string `json:"metadata"`
-	Tags            map[string]string `json:"tags"`
-	Created         time.Time         `json:"created"`
-	Updated         time.Time         `json:"updated"`
-	Docker          bool              `json:"docker"`
-	IPs             []string          `json:"ips"`
-	Networks        []string          `json:"networks"`
-	PrimaryIP       string            `json:"primaryIp"`
-	FirewallEnabled bool              `json:"firewall_enabled"`
-	ComputeNode     string            `json:"compute_node"`
-	Package         string            `json:"package"`
-	DomainNames     []string          `json:"dns_names"`
+	ID              string                 `json:"id"`
+	Name            string                 `json:"name"`
+	Type            string                 `json:"type"`
+	Brand           string                 `json:"brand"`
+	State           string                 `json:"state"`
+	Image           string                 `json:"image"`
+	Memory          int                    `json:"memory"`
+	Disk            int                    `json:"disk"`
+	Metadata        map[string]string      `json:"metadata"`
+	Tags            map[string]interface{} `json:"tags"`
+	Created         time.Time              `json:"created"`
+	Updated         time.Time              `json:"updated"`
+	Docker          bool                   `json:"docker"`
+	IPs             []string               `json:"ips"`
+	Networks        []string               `json:"networks"`
+	PrimaryIP       string                 `json:"primaryIp"`
+	FirewallEnabled bool                   `json:"firewall_enabled"`
+	ComputeNode     string                 `json:"compute_node"`
+	Package         string                 `json:"package"`
+	DomainNames     []string               `json:"dns_names"`
 	CNS             MachineCNS
 }
 
@@ -394,7 +392,7 @@ type ListMachineTagsInput struct {
 	ID string
 }
 
-func (client *MachinesClient) ListMachineTags(ctx context.Context, input *ListMachineTagsInput) (map[string]string, error) {
+func (client *MachinesClient) ListMachineTags(ctx context.Context, input *ListMachineTagsInput) (map[string]interface{}, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
 	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
@@ -676,14 +674,12 @@ var reservedMachineCNSTags = map[string]struct{}{
 
 // machineTagsExtractMeta() extracts all of the misc parameters from Tags and
 // returns a clean CNS and Tags struct.
-func machineTagsExtractMeta(tags map[string]interface{}) (MachineCNS, map[string]string) {
+func machineTagsExtractMeta(tags map[string]interface{}) (MachineCNS, map[string]interface{}) {
 	nativeCNS := MachineCNS{}
-	nativeTags := make(map[string]string, len(tags))
+	nativeTags := make(map[string]interface{}, len(tags))
 	for k, raw := range tags {
 		if _, found := reservedMachineCNSTags[k]; found {
 			switch k {
-			case machineSDCDocker:
-				nativeTags[k] = strconv.FormatBool(raw.(bool))
 			case machineCNSTagDisable:
 				b := raw.(bool)
 				nativeCNS.Disable = &b
@@ -696,7 +692,7 @@ func machineTagsExtractMeta(tags map[string]interface{}) (MachineCNS, map[string
 				// TODO(seanc@): should assert, logic fail
 			}
 		} else {
-			nativeTags[k] = raw.(string)
+			nativeTags[k] = raw
 		}
 	}
 

--- a/machines.go
+++ b/machines.go
@@ -669,7 +669,6 @@ var reservedMachineCNSTags = map[string]struct{}{
 	machineCNSTagDisable:    {},
 	machineCNSTagReversePTR: {},
 	machineCNSTagServices:   {},
-	machineSDCDocker:        {},
 }
 
 // machineTagsExtractMeta() extracts all of the misc parameters from Tags and


### PR DESCRIPTION
I was receiving a panic while attempting to perform `ListMachines` on my current account. This patch brings support for Docker API based Triton Machines that include the following tag...

```go
[01:41:56 triton-go/machines.go:679 github.com/joyent/triton-go.machineTagsExtractMeta]
1.610s tags=map[string]interface {}{
           "sdc_docker": bool(true),
       }
```

This patch returns the tag's value as a string during conversion within the `machineTagsExtractMeta` function. Here's the output for good measure...

```go
[01:57:44 triton-go/machines.go:705 github.com/joyent/triton-go.machineTagsExtractMeta]
1.727s nativeTags=map[string]string{"docker:label:com.docker.compose.service":"etcd", "docker:label:com.docker.compose.config-hash":"aae5113dc8eddf08b3fd902de5c06a07fa91a71645ce4
35df4d72b1d803024b3", "docker:label:com.docker.compose.project":"e", "docker:label:com.docker.compose.version":"1.9.0", "docker:label:com.docker.compose.oneoff":"False", "docker:
label:com.docker.compose.container-number":"4", "sdc_docker":"true"}
```