### PR TITLE
Align a few API names for datacenters and instances

### DIFF
--- a/compute/datacenters.go
+++ b/compute/datacenters.go
@@ -22,9 +22,9 @@ type DataCenter struct {
 	URL  string `json:"url"`
 }
 
-type ListInput struct{}
+type ListDataCentersInput struct{}
 
-func (c *DataCentersClient) List(ctx context.Context, _ *ListInput) ([]*DataCenter, error) {
+func (c *DataCentersClient) List(ctx context.Context, _ *ListDataCentersInput) ([]*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters", c.client.AccountName)
 	reqInputs := client.RequestInput{
 		Method: http.MethodGet,
@@ -65,11 +65,11 @@ func (c *DataCentersClient) List(ctx context.Context, _ *ListInput) ([]*DataCent
 	return result, nil
 }
 
-type GetInput struct {
+type GetDataCenterInput struct {
 	Name string
 }
 
-func (c *DataCentersClient) Get(ctx context.Context, input *GetInput) (*DataCenter, error) {
+func (c *DataCentersClient) Get(ctx context.Context, input *GetDataCenterInput) (*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters/%s", c.client.AccountName, input.Name)
 	reqInputs := client.RequestInput{
 		Method: http.MethodGet,

--- a/compute/datacenters_test.go
+++ b/compute/datacenters_test.go
@@ -32,7 +32,7 @@ func TestAccDataCenters_Get(t *testing.T) {
 				CallFunc: func(client interface{}) (interface{}, error) {
 					c := client.(*compute.ComputeClient)
 					ctx := context.Background()
-					input := &compute.GetInput{
+					input := &compute.GetDataCenterInput{
 						Name: dataCenterName,
 					}
 					return c.Datacenters().Get(ctx, input)
@@ -68,7 +68,7 @@ func TestAccDataCenters_List(t *testing.T) {
 				CallFunc: func(client interface{}) (interface{}, error) {
 					c := client.(*compute.ComputeClient)
 					ctx := context.Background()
-					input := &compute.ListInput{}
+					input := &compute.ListDataCentersInput{}
 					return c.Datacenters().List(ctx, input)
 				},
 			},

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -73,11 +73,11 @@ type NIC struct {
 	Network string `json:"network"`
 }
 
-type GetInstancesInput struct {
+type GetInstanceInput struct {
 	ID string
 }
 
-func (gmi *GetInstancesInput) Validate() error {
+func (gmi *GetInstanceInput) Validate() error {
 	if gmi.ID == "" {
 		return fmt.Errorf("machine ID can not be empty")
 	}
@@ -85,7 +85,7 @@ func (gmi *GetInstancesInput) Validate() error {
 	return nil
 }
 
-func (c *InstancesClient) Get(ctx context.Context, input *GetInstancesInput) (*Instance, error) {
+func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*Instance, error) {
 	if err := input.Validate(); err != nil {
 		return nil, errwrap.Wrapf("unable to get machine: {{err}}", err)
 	}

--- a/compute/instances_test.go
+++ b/compute/instances_test.go
@@ -51,7 +51,7 @@ func TestAccMachine_Get(t *testing.T) {
 					}
 
 					ctx := context.Background()
-					input := &compute.GetInstancesInput{
+					input := &compute.GetInstanceInput{
 						ID: machineID,
 					}
 					return c.Instances().Get(ctx, input)


### PR DESCRIPTION
While integrating with Terraform I found a few bugs in naming around datacenters and instances.