### PR TITLE
Use proper error types in client.DecodeError{}

### DIFF
--- a/account/account_test.go
+++ b/account/account_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -16,16 +15,16 @@ func TestAccAccount_Get(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "account",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return account.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "account",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.GetInput{}
+					input := &GetInput{}
 					return c.Get(ctx, input)
 				},
 			},

--- a/account/config_test.go
+++ b/account/config_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -16,16 +15,16 @@ func TestAccConfig_Get(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "config",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return account.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "config",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.GetConfigInput{}
+					input := &GetConfigInput{}
 					return c.Config().Get(ctx, input)
 				},
 			},

--- a/account/keys_test.go
+++ b/account/keys_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/abdullin/seq"
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -19,25 +18,25 @@ func TestAccKey_Create(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "key",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return account.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "key",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.CreateKeyInput{
+					input := &CreateKeyInput{
 						Name: keyName,
 						Key:  testAccCreateKeyMaterial,
 					}
 					return c.Keys().Create(ctx, input)
 				},
 				CleanupFunc: func(client interface{}, callState interface{}) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.DeleteKeyInput{
+					input := &DeleteKeyInput{
 						KeyName: keyName,
 					}
 					c.Keys().Delete(ctx, input)
@@ -64,25 +63,25 @@ func TestAccKey_Get(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "key",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return account.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "key",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.CreateKeyInput{
+					input := &CreateKeyInput{
 						Name: keyName,
 						Key:  testAccCreateKeyMaterial,
 					}
 					return c.Keys().Create(ctx, input)
 				},
 				CleanupFunc: func(client interface{}, callState interface{}) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.DeleteKeyInput{
+					input := &DeleteKeyInput{
 						KeyName: keyName,
 					}
 					c.Keys().Delete(ctx, input)
@@ -92,9 +91,9 @@ func TestAccKey_Get(t *testing.T) {
 			&testutils.StepAPICall{
 				StateBagKey: "getKey",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.GetKeyInput{
+					input := &GetKeyInput{
 						KeyName: keyName,
 					}
 					return c.Keys().Get(ctx, input)
@@ -122,25 +121,25 @@ func TestAccKey_Delete(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "key",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return account.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "key",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.CreateKeyInput{
+					input := &CreateKeyInput{
 						Name: keyName,
 						Key:  testAccCreateKeyMaterial,
 					}
 					return c.Keys().Create(ctx, input)
 				},
 				CleanupFunc: func(client interface{}, callState interface{}) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.DeleteKeyInput{
+					input := &DeleteKeyInput{
 						KeyName: keyName,
 					}
 					c.Keys().Delete(ctx, input)
@@ -150,9 +149,9 @@ func TestAccKey_Delete(t *testing.T) {
 			&testutils.StepAPICall{
 				StateBagKey: "noop",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.DeleteKeyInput{
+					input := &DeleteKeyInput{
 						KeyName: keyName,
 					}
 					return nil, c.Keys().Delete(ctx, input)
@@ -162,9 +161,9 @@ func TestAccKey_Delete(t *testing.T) {
 			&testutils.StepAPICall{
 				ErrorKey: "getKeyError",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*account.AccountClient)
+					c := client.(*AccountClient)
 					ctx := context.Background()
-					input := &account.GetKeyInput{
+					input := &GetKeyInput{
 						KeyName: keyName,
 					}
 					return c.Keys().Get(ctx, input)

--- a/client/client.go
+++ b/client/client.go
@@ -130,7 +130,7 @@ func doNotFollowRedirects(*http.Request, []*http.Request) error {
 // }
 
 func (c *Client) DecodeError(statusCode int, body io.Reader) error {
-	err := &ClientError{
+	err := &TritonError{
 		StatusCode: statusCode,
 	}
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -34,6 +34,21 @@ func (e MantaError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
 
+// TritonError represents an error code and message along with
+// the status code of the HTTP request which resulted in the error
+// message. Error codes used by the Triton API are listed at
+// https://apidocs.joyent.com/cloudapi/#cloudapi-http-responses
+type TritonError struct {
+	StatusCode int
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+}
+
+// Error implements interface Error on the TritonError type.
+func (e TritonError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
 func IsAuthSchemeError(err error) bool {
 	return isSpecificError(err, "AuthScheme")
 }

--- a/compute/datacenters_test.go
+++ b/compute/datacenters_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/abdullin/seq"
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/compute"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -23,16 +22,16 @@ func TestAccDataCenters_Get(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "datacenter",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return compute.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "datacenter",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*compute.ComputeClient)
+					c := client.(*ComputeClient)
 					ctx := context.Background()
-					input := &compute.GetDataCenterInput{
+					input := &GetDataCenterInput{
 						Name: dataCenterName,
 					}
 					return c.Datacenters().Get(ctx, input)
@@ -59,16 +58,16 @@ func TestAccDataCenters_List(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "datacenter",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return compute.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: "datacenters",
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*compute.ComputeClient)
+					c := client.(*ComputeClient)
 					ctx := context.Background()
-					input := &compute.ListDataCentersInput{}
+					input := &ListDataCentersInput{}
 					return c.Datacenters().List(ctx, input)
 				},
 			},
@@ -83,7 +82,7 @@ func TestAccDataCenters_List(t *testing.T) {
 					toFind := []string{"us-east-1", "eu-ams-1"}
 					for _, dcName := range toFind {
 						found := false
-						for _, dc := range dcs.([]*compute.DataCenter) {
+						for _, dc := range dcs.([]*DataCenter) {
 							if dc.Name == dcName {
 								found = true
 								if dc.URL == "" {

--- a/compute/errors.go
+++ b/compute/errors.go
@@ -1,128 +1,112 @@
 package compute
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/errwrap"
+	"github.com/joyent/triton-go/client"
 )
 
-// TritonError represents an error code and message along with
-// the status code of the HTTP request which resulted in the error
-// message. Error codes used by the Triton API are listed at
-// https://apidocs.joyent.com/cloudapi/#cloudapi-http-responses
-type TritonError struct {
-	StatusCode int
-	Code       string `json:"code"`
-	Message    string `json:"message"`
-}
-
-// Error implements interface Error on the TritonError type.
-func (e TritonError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
-
-// IsBadRequest tests whether err wraps a TritonError with
+// IsBadRequest tests whether err wraps a client.TritonError with
 // code BadRequest
 func IsBadRequest(err error) bool {
 	return isSpecificError(err, "BadRequest")
 }
 
-// IsInternalError tests whether err wraps a TritonError with
+// IsInternalError tests whether err wraps a client.TritonError with
 // code InternalError
 func IsInternalError(err error) bool {
 	return isSpecificError(err, "InternalError")
 }
 
-// IsInUseError tests whether err wraps a TritonError with
+// IsInUseError tests whether err wraps a client.TritonError with
 // code InUseError
 func IsInUseError(err error) bool {
 	return isSpecificError(err, "InUseError")
 }
 
-// IsInvalidArgument tests whether err wraps a TritonError with
+// IsInvalidArgument tests whether err wraps a client.TritonError with
 // code InvalidArgument
 func IsInvalidArgument(err error) bool {
 	return isSpecificError(err, "InvalidArgument")
 }
 
-// IsInvalidCredentials tests whether err wraps a TritonError with
+// IsInvalidCredentials tests whether err wraps a client.TritonError with
 // code InvalidCredentials
 func IsInvalidCredentials(err error) bool {
 	return isSpecificError(err, "InvalidCredentials")
 }
 
-// IsInvalidHeader tests whether err wraps a TritonError with
+// IsInvalidHeader tests whether err wraps a client.TritonError with
 // code InvalidHeader
 func IsInvalidHeader(err error) bool {
 	return isSpecificError(err, "InvalidHeader")
 }
 
-// IsInvalidVersion tests whether err wraps a TritonError with
+// IsInvalidVersion tests whether err wraps a client.TritonError with
 // code InvalidVersion
 func IsInvalidVersion(err error) bool {
 	return isSpecificError(err, "InvalidVersion")
 }
 
-// IsMissingParameter tests whether err wraps a TritonError with
+// IsMissingParameter tests whether err wraps a client.TritonError with
 // code MissingParameter
 func IsMissingParameter(err error) bool {
 	return isSpecificError(err, "MissingParameter")
 }
 
-// IsNotAuthorized tests whether err wraps a TritonError with
+// IsNotAuthorized tests whether err wraps a client.TritonError with
 // code NotAuthorized
 func IsNotAuthorized(err error) bool {
 	return isSpecificError(err, "NotAuthorized")
 }
 
-// IsRequestThrottled tests whether err wraps a TritonError with
+// IsRequestThrottled tests whether err wraps a client.TritonError with
 // code RequestThrottled
 func IsRequestThrottled(err error) bool {
 	return isSpecificError(err, "RequestThrottled")
 }
 
-// IsRequestTooLarge tests whether err wraps a TritonError with
+// IsRequestTooLarge tests whether err wraps a client.TritonError with
 // code RequestTooLarge
 func IsRequestTooLarge(err error) bool {
 	return isSpecificError(err, "RequestTooLarge")
 }
 
-// IsRequestMoved tests whether err wraps a TritonError with
+// IsRequestMoved tests whether err wraps a client.TritonError with
 // code RequestMoved
 func IsRequestMoved(err error) bool {
 	return isSpecificError(err, "RequestMoved")
 }
 
-// IsResourceFound tests whether err wraps a TritonError with code ResourceFound
+// IsResourceFound tests whether err wraps a client.TritonError with code ResourceFound
 func IsResourceFound(err error) bool {
 	return isSpecificError(err, "ResourceFound")
 }
 
-// IsResourceNotFound tests whether err wraps a TritonError with
+// IsResourceNotFound tests whether err wraps a client.TritonError with
 // code ResourceNotFound
 func IsResourceNotFound(err error) bool {
 	return isSpecificError(err, "ResourceNotFound")
 }
 
-// IsUnknownError tests whether err wraps a TritonError with
+// IsUnknownError tests whether err wraps a client.TritonError with
 // code UnknownError
 func IsUnknownError(err error) bool {
 	return isSpecificError(err, "UnknownError")
 }
 
 // isSpecificError checks whether the error represented by err wraps
-// an underlying TritonError with code errorCode.
+// an underlying client.TritonError with code errorCode.
 func isSpecificError(err error, errorCode string) bool {
 	if err == nil {
 		return false
 	}
 
-	tritonErrorInterface := errwrap.GetType(err.(error), &TritonError{})
+	tritonErrorInterface := errwrap.GetType(err.(error), &client.TritonError{})
 	if tritonErrorInterface == nil {
 		return false
 	}
 
-	tritonErr := tritonErrorInterface.(*TritonError)
+	tritonErr := tritonErrorInterface.(*client.TritonError)
 	if tritonErr.Code == errorCode {
 		return true
 	}

--- a/compute/images.go
+++ b/compute/images.go
@@ -39,7 +39,7 @@ type Image struct {
 	Tags         map[string]string      `json:"tags"`
 	EULA         string                 `json:"eula"`
 	ACL          []string               `json:"acl"`
-	Error        TritonError            `json:"error"`
+	Error        client.TritonError     `json:"error"`
 }
 
 type ListImagesInput struct {

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/abdullin/seq"
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/compute"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -24,16 +23,16 @@ func TestAccImagesList(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: stateKey,
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return compute.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*compute.ComputeClient)
+					c := client.(*ComputeClient)
 					ctx := context.Background()
-					input := &compute.ListImagesInput{}
+					input := &ListImagesInput{}
 					return c.Images().List(ctx, input)
 				},
 			},
@@ -48,7 +47,7 @@ func TestAccImagesList(t *testing.T) {
 					toFind := []string{image1Id, image2Id}
 					for _, imageID := range toFind {
 						found := false
-						for _, image := range images.([]*compute.Image) {
+						for _, image := range images.([]*Image) {
 							if image.ID == imageID {
 								found = true
 								state.Put(imageID, image)
@@ -96,16 +95,16 @@ func TestAccImagesListInput(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: stateKey,
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return compute.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*compute.ComputeClient)
+					c := client.(*ComputeClient)
 					ctx := context.Background()
-					input := &compute.ListImagesInput{
+					input := &ListImagesInput{
 						Name:    "ubuntu-14.04",
 						Type:    "lx-dataset",
 						Version: "20160219",
@@ -124,7 +123,7 @@ func TestAccImagesListInput(t *testing.T) {
 					toFind := []string{image1Id}
 					for _, imageID := range toFind {
 						found := false
-						for _, image := range images.([]*compute.Image) {
+						for _, image := range images.([]*Image) {
 							if image.ID == imageID {
 								found = true
 								state.Put(imageID, image)
@@ -166,16 +165,16 @@ func TestAccImagesGet(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: stateKey,
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return compute.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*compute.ComputeClient)
+					c := client.(*ComputeClient)
 					ctx := context.Background()
-					input := &compute.GetImageInput{
+					input := &GetImageInput{
 						ImageID: imageId,
 					}
 					return c.Images().Get(ctx, input)

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -101,7 +101,7 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 		defer response.Body.Close()
 	}
 	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
-		return nil, &TritonError{
+		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}
@@ -532,7 +532,7 @@ func (c *InstancesClient) GetMetadata(ctx context.Context, input *GetMetadataInp
 		defer response.Body.Close()
 	}
 	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
-		return "", &TritonError{
+		return "", &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}
@@ -789,7 +789,7 @@ func (c *InstancesClient) GetNIC(ctx context.Context, input *GetNICInput) (*NIC,
 	}
 	switch response.StatusCode {
 	case http.StatusNotFound:
-		return nil, &TritonError{
+		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}
@@ -830,7 +830,7 @@ func (c *InstancesClient) AddNIC(ctx context.Context, input *AddNICInput) (*NIC,
 	}
 	switch response.StatusCode {
 	case http.StatusFound:
-		return nil, &TritonError{
+		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceFound",
 			Message:    response.Header.Get("Location"),
@@ -871,7 +871,7 @@ func (c *InstancesClient) RemoveNIC(ctx context.Context, input *RemoveNICInput) 
 	}
 	switch response.StatusCode {
 	case http.StatusNotFound:
-		return &TritonError{
+		return &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}

--- a/compute/services_test.go
+++ b/compute/services_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/compute"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -19,16 +18,16 @@ func TestAccServicesList(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: stateKey,
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return compute.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
 			&testutils.StepAPICall{
 				StateBagKey: stateKey,
 				CallFunc: func(client interface{}) (interface{}, error) {
-					c := client.(*compute.ComputeClient)
+					c := client.(*ComputeClient)
 					ctx := context.Background()
-					input := &compute.ListServicesInput{}
+					input := &ListServicesInput{}
 					return c.Services().List(ctx, input)
 				},
 			},
@@ -43,7 +42,7 @@ func TestAccServicesList(t *testing.T) {
 					toFind := []string{"docker"}
 					for _, serviceName := range toFind {
 						found := false
-						for _, service := range services.([]*compute.Service) {
+						for _, service := range services.([]*Service) {
 							if service.Name == serviceName {
 								found = true
 								if service.Endpoint == "" {

--- a/examples/account/account_info.go
+++ b/examples/account/account_info.go
@@ -53,14 +53,14 @@ func main() {
 	printAccount(acct)
 
 	input := &account.UpdateInput{
-		CompanyName: fmt.Sprintf("%s-old", oldName)
+		CompanyName: fmt.Sprintf("%s-old", acct.CompanyName),
 	}
 
-	acct, err := a.Update(context.Background(), input)
+	updatedAcct, err := a.Update(context.Background(), input)
 	if err != nil {
 		log.Fatalf("account.Update: %v", err)
 	}
 
 	fmt.Println("New ----")
-	printAccount(acct)
+	printAccount(updatedAcct)
 }

--- a/network/networks_test.go
+++ b/network/networks_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/network"
 	"github.com/joyent/triton-go/testutils"
 )
 
@@ -19,7 +18,7 @@ func TestAccNetworks_List(t *testing.T) {
 			&testutils.StepClient{
 				StateBagKey: "datacenter",
 				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
-					return network.NewClient(config)
+					return NewClient(config)
 				},
 			},
 
@@ -27,8 +26,8 @@ func TestAccNetworks_List(t *testing.T) {
 				StateBagKey: "networks",
 				CallFunc: func(client interface{}) (interface{}, error) {
 					ctx := context.Background()
-					input := &network.ListInput{}
-					if c, ok := client.(*network.NetworkClient); ok {
+					input := &ListInput{}
+					if c, ok := client.(*NetworkClient); ok {
 						return c.List(ctx, input)
 					}
 					return nil, fmt.Errorf("Bad client initialization")
@@ -45,7 +44,7 @@ func TestAccNetworks_List(t *testing.T) {
 					toFind := []string{"Joyent-SDC-Private", "Joyent-SDC-Public"}
 					for _, dcName := range toFind {
 						found := false
-						for _, dc := range dcs.([]*network.Network) {
+						for _, dc := range dcs.([]*Network) {
 							if dc.Name == dcName {
 								found = true
 								if dc.Id == "" {

--- a/testutils/steps.go
+++ b/testutils/steps.go
@@ -10,7 +10,7 @@ import (
 	"github.com/abdullin/seq"
 	"github.com/hashicorp/errwrap"
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/compute"
+	"github.com/joyent/triton-go/client"
 )
 
 type StepClient struct {
@@ -194,13 +194,13 @@ func (s *StepAssertTritonError) Run(state TritonStateBag) StepAction {
 		return Halt
 	}
 
-	tritonErrorInterface := errwrap.GetType(err.(error), &compute.TritonError{})
+	tritonErrorInterface := errwrap.GetType(err.(error), &client.TritonError{})
 	if tritonErrorInterface == nil {
 		state.AppendError(errors.New("Expected a TritonError in wrapped error chain"))
 		return Halt
 	}
 
-	tritonErr := tritonErrorInterface.(*compute.TritonError)
+	tritonErr := tritonErrorInterface.(*client.TritonError)
 	if tritonErr.Code == s.Code {
 		return Continue
 	}


### PR DESCRIPTION
The original bug stems from `client.DecodeError()` returning a `client.ClientError{}` not a `client.TritonError{}`.  Chase relocating `compute.TritonError` into `client.TritonError` which is the leaf in the package import graph.

The incorrect error type was discovered while using the Terraform Triton provider.

Discussed with: @cheapRoc and @stack72 