### PR TITLE
Move compute.TritonError to client.TritonError

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -130,7 +130,7 @@ func doNotFollowRedirects(*http.Request, []*http.Request) error {
 // }
 
 func (c *Client) DecodeError(statusCode int, body io.Reader) error {
-	err := &ClientError{
+	err := &TritonError{
 		StatusCode: statusCode,
 	}
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -34,6 +34,21 @@ func (e MantaError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
 
+// TritonError represents an error code and message along with
+// the status code of the HTTP request which resulted in the error
+// message. Error codes used by the Triton API are listed at
+// https://apidocs.joyent.com/cloudapi/#cloudapi-http-responses
+type TritonError struct {
+	StatusCode int
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+}
+
+// Error implements interface Error on the TritonError type.
+func (e TritonError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
 func IsAuthSchemeError(err error) bool {
 	return isSpecificError(err, "AuthScheme")
 }

--- a/compute/errors.go
+++ b/compute/errors.go
@@ -1,128 +1,112 @@
 package compute
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/errwrap"
+	"github.com/joyent/triton-go/client"
 )
 
-// TritonError represents an error code and message along with
-// the status code of the HTTP request which resulted in the error
-// message. Error codes used by the Triton API are listed at
-// https://apidocs.joyent.com/cloudapi/#cloudapi-http-responses
-type TritonError struct {
-	StatusCode int
-	Code       string `json:"code"`
-	Message    string `json:"message"`
-}
-
-// Error implements interface Error on the TritonError type.
-func (e TritonError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
-
-// IsBadRequest tests whether err wraps a TritonError with
+// IsBadRequest tests whether err wraps a client.TritonError with
 // code BadRequest
 func IsBadRequest(err error) bool {
 	return isSpecificError(err, "BadRequest")
 }
 
-// IsInternalError tests whether err wraps a TritonError with
+// IsInternalError tests whether err wraps a client.TritonError with
 // code InternalError
 func IsInternalError(err error) bool {
 	return isSpecificError(err, "InternalError")
 }
 
-// IsInUseError tests whether err wraps a TritonError with
+// IsInUseError tests whether err wraps a client.TritonError with
 // code InUseError
 func IsInUseError(err error) bool {
 	return isSpecificError(err, "InUseError")
 }
 
-// IsInvalidArgument tests whether err wraps a TritonError with
+// IsInvalidArgument tests whether err wraps a client.TritonError with
 // code InvalidArgument
 func IsInvalidArgument(err error) bool {
 	return isSpecificError(err, "InvalidArgument")
 }
 
-// IsInvalidCredentials tests whether err wraps a TritonError with
+// IsInvalidCredentials tests whether err wraps a client.TritonError with
 // code InvalidCredentials
 func IsInvalidCredentials(err error) bool {
 	return isSpecificError(err, "InvalidCredentials")
 }
 
-// IsInvalidHeader tests whether err wraps a TritonError with
+// IsInvalidHeader tests whether err wraps a client.TritonError with
 // code InvalidHeader
 func IsInvalidHeader(err error) bool {
 	return isSpecificError(err, "InvalidHeader")
 }
 
-// IsInvalidVersion tests whether err wraps a TritonError with
+// IsInvalidVersion tests whether err wraps a client.TritonError with
 // code InvalidVersion
 func IsInvalidVersion(err error) bool {
 	return isSpecificError(err, "InvalidVersion")
 }
 
-// IsMissingParameter tests whether err wraps a TritonError with
+// IsMissingParameter tests whether err wraps a client.TritonError with
 // code MissingParameter
 func IsMissingParameter(err error) bool {
 	return isSpecificError(err, "MissingParameter")
 }
 
-// IsNotAuthorized tests whether err wraps a TritonError with
+// IsNotAuthorized tests whether err wraps a client.TritonError with
 // code NotAuthorized
 func IsNotAuthorized(err error) bool {
 	return isSpecificError(err, "NotAuthorized")
 }
 
-// IsRequestThrottled tests whether err wraps a TritonError with
+// IsRequestThrottled tests whether err wraps a client.TritonError with
 // code RequestThrottled
 func IsRequestThrottled(err error) bool {
 	return isSpecificError(err, "RequestThrottled")
 }
 
-// IsRequestTooLarge tests whether err wraps a TritonError with
+// IsRequestTooLarge tests whether err wraps a client.TritonError with
 // code RequestTooLarge
 func IsRequestTooLarge(err error) bool {
 	return isSpecificError(err, "RequestTooLarge")
 }
 
-// IsRequestMoved tests whether err wraps a TritonError with
+// IsRequestMoved tests whether err wraps a client.TritonError with
 // code RequestMoved
 func IsRequestMoved(err error) bool {
 	return isSpecificError(err, "RequestMoved")
 }
 
-// IsResourceFound tests whether err wraps a TritonError with code ResourceFound
+// IsResourceFound tests whether err wraps a client.TritonError with code ResourceFound
 func IsResourceFound(err error) bool {
 	return isSpecificError(err, "ResourceFound")
 }
 
-// IsResourceNotFound tests whether err wraps a TritonError with
+// IsResourceNotFound tests whether err wraps a client.TritonError with
 // code ResourceNotFound
 func IsResourceNotFound(err error) bool {
 	return isSpecificError(err, "ResourceNotFound")
 }
 
-// IsUnknownError tests whether err wraps a TritonError with
+// IsUnknownError tests whether err wraps a client.TritonError with
 // code UnknownError
 func IsUnknownError(err error) bool {
 	return isSpecificError(err, "UnknownError")
 }
 
 // isSpecificError checks whether the error represented by err wraps
-// an underlying TritonError with code errorCode.
+// an underlying client.TritonError with code errorCode.
 func isSpecificError(err error, errorCode string) bool {
 	if err == nil {
 		return false
 	}
 
-	tritonErrorInterface := errwrap.GetType(err.(error), &TritonError{})
+	tritonErrorInterface := errwrap.GetType(err.(error), &client.TritonError{})
 	if tritonErrorInterface == nil {
 		return false
 	}
 
-	tritonErr := tritonErrorInterface.(*TritonError)
+	tritonErr := tritonErrorInterface.(*client.TritonError)
 	if tritonErr.Code == errorCode {
 		return true
 	}

--- a/compute/images.go
+++ b/compute/images.go
@@ -39,7 +39,7 @@ type Image struct {
 	Tags         map[string]string      `json:"tags"`
 	EULA         string                 `json:"eula"`
 	ACL          []string               `json:"acl"`
-	Error        TritonError            `json:"error"`
+	Error        client.TritonError     `json:"error"`
 }
 
 type ListImagesInput struct {

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -101,7 +101,7 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 		defer response.Body.Close()
 	}
 	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
-		return nil, &TritonError{
+		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}
@@ -532,7 +532,7 @@ func (c *InstancesClient) GetMetadata(ctx context.Context, input *GetMetadataInp
 		defer response.Body.Close()
 	}
 	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
-		return "", &TritonError{
+		return "", &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}
@@ -789,7 +789,7 @@ func (c *InstancesClient) GetNIC(ctx context.Context, input *GetNICInput) (*NIC,
 	}
 	switch response.StatusCode {
 	case http.StatusNotFound:
-		return nil, &TritonError{
+		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}
@@ -830,7 +830,7 @@ func (c *InstancesClient) AddNIC(ctx context.Context, input *AddNICInput) (*NIC,
 	}
 	switch response.StatusCode {
 	case http.StatusFound:
-		return nil, &TritonError{
+		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceFound",
 			Message:    response.Header.Get("Location"),
@@ -871,7 +871,7 @@ func (c *InstancesClient) RemoveNIC(ctx context.Context, input *RemoveNICInput) 
 	}
 	switch response.StatusCode {
 	case http.StatusNotFound:
-		return &TritonError{
+		return &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",
 		}

--- a/testutils/steps.go
+++ b/testutils/steps.go
@@ -10,7 +10,7 @@ import (
 	"github.com/abdullin/seq"
 	"github.com/hashicorp/errwrap"
 	triton "github.com/joyent/triton-go"
-	"github.com/joyent/triton-go/compute"
+	"github.com/joyent/triton-go/client"
 )
 
 type StepClient struct {
@@ -194,13 +194,13 @@ func (s *StepAssertTritonError) Run(state TritonStateBag) StepAction {
 		return Halt
 	}
 
-	tritonErrorInterface := errwrap.GetType(err.(error), &compute.TritonError{})
+	tritonErrorInterface := errwrap.GetType(err.(error), &client.TritonError{})
 	if tritonErrorInterface == nil {
 		state.AppendError(errors.New("Expected a TritonError in wrapped error chain"))
 		return Halt
 	}
 
-	tritonErr := tritonErrorInterface.(*compute.TritonError)
+	tritonErr := tritonErrorInterface.(*client.TritonError)
 	if tritonErr.Code == s.Code {
 		return Continue
 	}


### PR DESCRIPTION
Ref: #38 

The original bug stems from `client.DecodeError()` returning a `client.ClientError{}`
not a `client.TritonError{}`.  Chase relocating `compute.TritonError` into
`client.TritonError` which is the leaf in the package import graph.

Discussed with: @sean- and @stack72