### PR TITLE
Missing omitempty when creating a fabric network or firewall rule

### DIFF
--- a/examples/network/create_fabric.go
+++ b/examples/network/create_fabric.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	triton "github.com/joyent/triton-go"
+	"github.com/joyent/triton-go/authentication"
+	"github.com/joyent/triton-go/network"
+)
+
+func main() {
+	keyID, foundKey := os.LookupEnv("SDC_KEY_ID")
+	if !foundKey {
+		log.Fatal("Couldn't find \"SDC_KEY_ID\" in your environment")
+	}
+
+	accountName, foundAccount := os.LookupEnv("SDC_ACCOUNT")
+	if !foundAccount {
+		log.Fatal("Couldn't find \"SDC_ACCOUNT\" in your environment")
+	}
+
+	tritonURL, foundURL := os.LookupEnv("SDC_URL")
+	if !foundURL {
+		log.Fatal("Couldn't find \"SDC_URL\" in your environment")
+	}
+
+	signer, err := authentication.NewSSHAgentSigner(keyID, accountName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config := &triton.ClientConfig{
+		TritonURL:   tritonURL,
+		AccountName: accountName,
+		Signers:     []authentication.Signer{signer},
+	}
+	n, err := network.NewClient(config)
+	if err != nil {
+		log.Fatalf("Network NewClient(): %s", err)
+	}
+
+	fabric, err := n.Fabrics().Create(context.Background(), &network.CreateFabricInput{
+		FabricVLANID:     2,
+		Name:             "testnet",
+		Description:      "This is a test network",
+		Subnet:           "10.50.1.0/24",
+		ProvisionStartIP: "10.50.1.10",
+		ProvisionEndIP:   "10.50.1.240",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Fabric was successfully created!")
+	fmt.Println("Name:", fabric.Name)
+	time.Sleep(5 * time.Second)
+
+	err = n.Fabrics().Delete(context.Background(), &network.DeleteFabricInput{
+		FabricVLANID: 2,
+		NetworkID:    fabric.Id,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Fabric was successfully deleted!")
+	time.Sleep(5 * time.Second)
+
+	fwrule, err := n.Firewall().CreateRule(context.Background(), &network.CreateRuleInput{
+		Enabled: false,
+		Rule:    "FROM any TO tag \"bone-thug\" = \"basket-ball\" ALLOW udp PORT 8600",
+	})
+
+	fmt.Println("Firewall Rule was successfully added!")
+	time.Sleep(5 * time.Second)
+
+	err = n.Firewall().DeleteRule(context.Background(), &network.DeleteRuleInput{
+		ID: fwrule.ID,
+	})
+
+	fmt.Println("Firewall Rule was successfully deleted!")
+	time.Sleep(5 * time.Second)
+
+}

--- a/network/fabrics.go
+++ b/network/fabrics.go
@@ -49,7 +49,7 @@ func (c *FabricsClient) ListVLANs(ctx context.Context, _ *ListVLANsInput) ([]*Fa
 type CreateVLANInput struct {
 	Name        string `json:"name"`
 	ID          int    `json:"vlan_id"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 func (c *FabricsClient) CreateVLAN(ctx context.Context, input *CreateVLANInput) (*FabricVLAN, error) {
@@ -184,13 +184,13 @@ func (c *FabricsClient) List(ctx context.Context, input *ListFabricsInput) ([]*N
 type CreateFabricInput struct {
 	FabricVLANID     int               `json:"-"`
 	Name             string            `json:"name"`
-	Description      string            `json:"description"`
+	Description      string            `json:"description,omitempty"`
 	Subnet           string            `json:"subnet"`
 	ProvisionStartIP string            `json:"provision_start_ip"`
 	ProvisionEndIP   string            `json:"provision_end_ip"`
-	Gateway          string            `json:"gateway"`
-	Resolvers        []string          `json:"resolvers"`
-	Routes           map[string]string `json:"routes"`
+	Gateway          string            `json:"gateway,omitempty"`
+	Resolvers        []string          `json:"resolvers,omitempty"`
+	Routes           map[string]string `json:"routes,omitempty"`
 	InternetNAT      bool              `json:"internet_nat"`
 }
 

--- a/network/firewall.go
+++ b/network/firewall.go
@@ -87,7 +87,7 @@ func (c *FirewallClient) GetRule(ctx context.Context, input *GetRuleInput) (*Fir
 type CreateRuleInput struct {
 	Enabled     bool   `json:"enabled"`
 	Rule        string `json:"rule"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 func (c *FirewallClient) CreateRule(ctx context.Context, input *CreateRuleInput) (*FirewallRule, error) {
@@ -118,7 +118,7 @@ type UpdateRuleInput struct {
 	ID          string `json:"-"`
 	Enabled     bool   `json:"enabled"`
 	Rule        string `json:"rule"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 func (c *FirewallClient) UpdateRule(ctx context.Context, input *UpdateRuleInput) (*FirewallRule, error) {


### PR DESCRIPTION
Patch a bug that was found downstream by terraform-providers/terraform-provider-triton#28. Simply missing `omitempty` in a few cases. I'll push the Terraform vendor PR as well.