### PR TITLE
Fix Snaplink Headers

### DIFF
--- a/storage/snaplink.go
+++ b/storage/snaplink.go
@@ -23,7 +23,6 @@ type PutSnapLinkInput struct {
 func (s *SnapLinksClient) Put(ctx context.Context, input *PutSnapLinkInput) error {
 	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.LinkPath)
 	headers := &http.Header{}
-	headers.Set("Content-Type", "application/json; type=link")
 	headers.Set("Location", input.SourcePath)
 
 	reqInput := client.RequestInput{


### PR DESCRIPTION
When making a snaplink via triton-go, the presence of:

```
headers.Set("Content-Type", "application/json; type=link")
```

was causing the snaplink to fail with the error:

```
{
	"code": "SourceObjectNotFound",
	"message": "/stor/stack72-test3/assets.zip was not found"
}
```

By examining the manta cli tools, I was able to find that the cli doesn't need the presence of a Content-Type header. Therefore, removing the Content-Type header, and we get the correct behaviour - which in this case is a 204 response