### PR TITLE
Unify the way we tell people how to initialize client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,23 +144,50 @@ import (
 func main() {
     keyID := os.Getenv("SDC_KEY_ID")
     accountName := os.Getenv("SDC_ACCOUNT")
-    keyPath := os.Getenv("SDC_KEY_FILE")
+    keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-    privateKey, err := ioutil.ReadFile(keyPath)
-    if err != nil {
-        log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-    }
+    var signer authentication.Signer
+    var err error
 
-    sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-    if err != nil {
-        log.Fatal(err)
+    if keyMaterial == "" {
+        signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+        if err != nil {
+            log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+        }
+    } else {
+        var keyBytes []byte
+        if _, err = os.Stat(keyMaterial); err == nil {
+            keyBytes, err = ioutil.ReadFile(keyMaterial)
+            if err != nil {
+                log.Fatalf("Error reading key material from %s: %s",
+                    keyMaterial, err)
+            }
+            block, _ := pem.Decode(keyBytes)
+            if block == nil {
+                log.Fatalf(
+                    "Failed to read key material '%s': no key found", keyMaterial)
+            }
+
+            if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+                log.Fatalf(
+                    "Failed to read key '%s': password protected keys are\n"+
+                        "not currently supported. Please decrypt the key prior to use.", keyMaterial)
+            }
+
+        } else {
+            keyBytes = []byte(keyMaterial)
+        }
+
+        signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+        if err != nil {
+            log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+        }
     }
 
     config := &triton.ClientConfig{
         TritonURL:   os.Getenv("SDC_URL"),
-        MantaURL:    os.Getenv("MANTA_URL"),
         AccountName: accountName,
-        Signers:     []authentication.Signer{sshKeySigner},
+        Signers:     []authentication.Signer{signer},
     }
 
     c, err := compute.NewClient(config)

--- a/examples/account/account_info.go
+++ b/examples/account/account_info.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 
+	"encoding/pem"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/authentication"
@@ -21,22 +23,50 @@ func printAccount(acct *account.Account) {
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
 		TritonURL:   os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
 
 	a, err := account.NewClient(config)

--- a/examples/account/config.go
+++ b/examples/account/config.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 
+	"encoding/pem"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/authentication"
@@ -16,22 +18,50 @@ import (
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
 		TritonURL:   os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
 
 	nc, err := network.NewClient(config)

--- a/examples/account/keys.go
+++ b/examples/account/keys.go
@@ -6,34 +6,59 @@ import (
 	"log"
 	"os"
 
+	"encoding/pem"
+	"io/ioutil"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/authentication"
 )
 
 func main() {
-	keyID, foundKey := os.LookupEnv("SDC_KEY_ID")
-	if !foundKey {
-		log.Fatal("Couldn't find \"SDC_KEY_ID\" in your environment")
-	}
+	keyID := os.Getenv("SDC_KEY_ID")
+	accountName := os.Getenv("SDC_ACCOUNT")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	accountName, foundAccount := os.LookupEnv("SDC_ACCOUNT")
-	if !foundAccount {
-		log.Fatal("Couldn't find \"SDC_ACCOUNT\" in your environment")
-	}
+	var signer authentication.Signer
+	var err error
 
-	tritonURL, foundURL := os.LookupEnv("SDC_URL")
-	if !foundURL {
-		log.Fatal("Couldn't find \"SDC_URL\" in your environment")
-	}
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
 
-	signer, err := authentication.NewSSHAgentSigner(keyID, accountName)
-	if err != nil {
-		log.Fatal(err)
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		TritonURL:   tritonURL,
+		TritonURL:   os.Getenv("SDC_URL"),
 		AccountName: accountName,
 		Signers:     []authentication.Signer{signer},
 	}

--- a/examples/compute/create_instance.go
+++ b/examples/compute/create_instance.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -21,31 +23,54 @@ const (
 )
 
 func main() {
-	keyID, foundKey := os.LookupEnv("SDC_KEY_ID")
-	if !foundKey {
-		log.Fatal("Couldn't find \"SDC_KEY_ID\" in your environment")
-	}
+	keyID := os.Getenv("SDC_KEY_ID")
+	accountName := os.Getenv("SDC_ACCOUNT")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	accountName, foundAccount := os.LookupEnv("SDC_ACCOUNT")
-	if !foundAccount {
-		log.Fatal("Couldn't find \"SDC_ACCOUNT\" in your environment")
-	}
+	var signer authentication.Signer
+	var err error
 
-	tritonURL, foundURL := os.LookupEnv("SDC_URL")
-	if !foundURL {
-		log.Fatal("Couldn't find \"SDC_URL\" in your environment")
-	}
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
 
-	signer, err := authentication.NewSSHAgentSigner(keyID, accountName)
-	if err != nil {
-		log.Fatal(err)
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		TritonURL:   tritonURL,
+		TritonURL:   os.Getenv("SDC_URL"),
 		AccountName: accountName,
 		Signers:     []authentication.Signer{signer},
 	}
+
 	c, err := compute.NewClient(config)
 	if err != nil {
 		log.Fatalf("Compute NewClient(): %s", err)

--- a/examples/compute/instances.go
+++ b/examples/compute/instances.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -15,23 +16,50 @@ import (
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
 		TritonURL:   os.Getenv("SDC_URL"),
-		MantaURL:    os.Getenv("MANTA_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
 
 	c, err := compute.NewClient(config)

--- a/examples/network/create_fabric.go
+++ b/examples/network/create_fabric.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -13,31 +15,54 @@ import (
 )
 
 func main() {
-	keyID, foundKey := os.LookupEnv("SDC_KEY_ID")
-	if !foundKey {
-		log.Fatal("Couldn't find \"SDC_KEY_ID\" in your environment")
-	}
+	keyID := os.Getenv("SDC_KEY_ID")
+	accountName := os.Getenv("SDC_ACCOUNT")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	accountName, foundAccount := os.LookupEnv("SDC_ACCOUNT")
-	if !foundAccount {
-		log.Fatal("Couldn't find \"SDC_ACCOUNT\" in your environment")
-	}
+	var signer authentication.Signer
+	var err error
 
-	tritonURL, foundURL := os.LookupEnv("SDC_URL")
-	if !foundURL {
-		log.Fatal("Couldn't find \"SDC_URL\" in your environment")
-	}
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
 
-	signer, err := authentication.NewSSHAgentSigner(keyID, accountName)
-	if err != nil {
-		log.Fatal(err)
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		TritonURL:   tritonURL,
+		TritonURL:   os.Getenv("SDC_URL"),
 		AccountName: accountName,
 		Signers:     []authentication.Signer{signer},
 	}
+
 	n, err := network.NewClient(config)
 	if err != nil {
 		log.Fatalf("Network NewClient(): %s", err)

--- a/examples/storage/createjob.go
+++ b/examples/storage/createjob.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	"encoding/pem"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
 	"github.com/joyent/triton-go/storage"
@@ -17,23 +19,52 @@ import (
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("MANTA_URL"),
+		MantaURL:    os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
+
 	client, err := storage.NewClient(config)
 	if err != nil {
 		log.Fatalf("NewClient: %s", err)

--- a/examples/storage/getobject.go
+++ b/examples/storage/getobject.go
@@ -10,28 +10,58 @@ import (
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
 	"github.com/joyent/triton-go/storage"
+	"encoding/pem"
 )
 
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("MANTA_URL"),
+		MantaURL:    os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
+
 	client, err := storage.NewClient(config)
 	if err != nil {
 		log.Fatalf("NewClient: %s", err)

--- a/examples/storage/mls.go
+++ b/examples/storage/mls.go
@@ -10,28 +10,58 @@ import (
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
 	"github.com/joyent/triton-go/storage"
+	"encoding/pem"
 )
 
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("MANTA_URL"),
+		MantaURL:    os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
+
 	client, err := storage.NewClient(config)
 	if err != nil {
 		log.Fatalf("NewClient: %s", err)

--- a/examples/storage/putobject.go
+++ b/examples/storage/putobject.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 
+	"encoding/pem"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
 	"github.com/joyent/triton-go/storage"
@@ -15,23 +17,52 @@ import (
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("MANTA_URL"),
+		MantaURL:    os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
+
 	client, err := storage.NewClient(config)
 	if err != nil {
 		log.Fatalf("NewClient: %s", err)

--- a/examples/storage/signUrl.go
+++ b/examples/storage/signUrl.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/pem"
 	"io/ioutil"
 	"log"
 	"os"
@@ -16,23 +17,52 @@ import (
 func main() {
 	keyID := os.Getenv("SDC_KEY_ID")
 	accountName := os.Getenv("SDC_ACCOUNT")
-	keyPath := os.Getenv("SDC_KEY_FILE")
+	keyMaterial := os.Getenv("SDC_KEY_MATERIAL")
 
-	privateKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		log.Fatalf("Couldn't find key file matching %s\n%s", keyID, err)
-	}
+	var signer authentication.Signer
+	var err error
 
-	sshKeySigner, err := authentication.NewPrivateKeySigner(keyID, privateKey, accountName)
-	if err != nil {
-		log.Fatal(err)
+	if keyMaterial == "" {
+		signer, err = authentication.NewSSHAgentSigner(keyID, accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Agent Signer: {{err}}", err)
+		}
+	} else {
+		var keyBytes []byte
+		if _, err = os.Stat(keyMaterial); err == nil {
+			keyBytes, err = ioutil.ReadFile(keyMaterial)
+			if err != nil {
+				log.Fatalf("Error reading key material from %s: %s",
+					keyMaterial, err)
+			}
+			block, _ := pem.Decode(keyBytes)
+			if block == nil {
+				log.Fatalf(
+					"Failed to read key material '%s': no key found", keyMaterial)
+			}
+
+			if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
+				log.Fatalf(
+					"Failed to read key '%s': password protected keys are\n"+
+						"not currently supported. Please decrypt the key prior to use.", keyMaterial)
+			}
+
+		} else {
+			keyBytes = []byte(keyMaterial)
+		}
+
+		signer, err = authentication.NewPrivateKeySigner(keyID, []byte(keyMaterial), accountName)
+		if err != nil {
+			log.Fatalf("Error Creating SSH Private Key Signer: {{err}}", err)
+		}
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("MANTA_URL"),
+		MantaURL:    os.Getenv("SDC_URL"),
 		AccountName: accountName,
-		Signers:     []authentication.Signer{sshKeySigner},
+		Signers:     []authentication.Signer{signer},
 	}
+
 	client, err := storage.NewClient(config)
 	if err != nil {
 		log.Fatalf("NewClient: %s", err)


### PR DESCRIPTION
This supports the 3 keys ways:

* SSH Agent signer
* Passing a path to an SSH Key
* Passing the contents of an SSH KEy