### PR TITLE
Guard against panic when Delete request fails

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -322,6 +322,9 @@ func (c *InstancesClient) Delete(ctx context.Context, input *DeleteInstanceInput
 		Path:   path,
 	}
 	response, err := c.client.ExecuteRequestRaw(ctx, reqInputs)
+	if response == nil {
+		return fmt.Errorf("Delete request has empty response")
+	}
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -347,6 +350,9 @@ func (c *InstancesClient) DeleteTags(ctx context.Context, input *DeleteTagsInput
 		Path:   path,
 	}
 	response, err := c.client.ExecuteRequestRaw(ctx, reqInputs)
+	if response == nil {
+		return fmt.Errorf("DeleteTags request has empty response")
+	}
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -373,6 +379,9 @@ func (c *InstancesClient) DeleteTag(ctx context.Context, input *DeleteTagInput) 
 		Path:   path,
 	}
 	response, err := c.client.ExecuteRequestRaw(ctx, reqInputs)
+	if response == nil {
+		return fmt.Errorf("DeleteTag request has empty response")
+	}
 	if response.Body != nil {
 		defer response.Body.Close()
 	}


### PR DESCRIPTION
As reported in company chat, when wifi failed during a delete response, a panic was received:

```
panic: runtime error: invalid memory address or nil pointer dereference
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x15ba596]
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4:
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4: goroutine 54 [running]:
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4: github.com/terraform-providers/terraform-provider-triton/vendor/github.com/joyent/triton-go/compute.(*InstancesClient).Delete(0xc420063988, 0x1b90160, 0xc420014060, 0xc42003f990, 0x0, 0x0)
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-triton/vendor/github.com/joyent/triton-go/compute/instances.go:307 +0x1d6
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4: github.com/terraform-providers/terraform-provider-triton/triton.resourceMachineDelete(0xc420262ee0, 0x16e9340, 0xc42038af30, 0x0, 0xc42030f708)
2017-10-17T08:40:01.520-0700 [DEBUG] plugin.terraform-provider-triton_v0.2.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-triton/triton/resource_machine.go:842 +0xf9
```

We should guard against this to make sure we don't panic on the user