### PR TITLE
Support CloudAPI's Ping endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0 (November 2)
+
+- Introduce CloudAPI's Ping under compute
+- Introduce CloudAPI's RebootMachine under compute instances
+- tools: Introduce unit testing and scripts for linting, etc.
+
 ## 0.1.0 (November 2)
 
-Initial release of a versioned SDK
+- Initial release of a versioned SDK

--- a/compute/errors.go
+++ b/compute/errors.go
@@ -94,6 +94,12 @@ func IsUnknownError(err error) bool {
 	return isSpecificError(err, "UnknownError")
 }
 
+// IsEmptyResponse tests whether err wraps a client.TritonError with code
+// EmptyResponse
+func IsEmptyResponse(err error) bool {
+	return isSpecificError(err, "EmptyResponse")
+}
+
 // isSpecificError checks whether the error represented by err wraps
 // an underlying client.TritonError with code errorCode.
 func isSpecificError(err error, errorCode string) bool {

--- a/compute/ping.go
+++ b/compute/ping.go
@@ -1,0 +1,56 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/joyent/triton-go/client"
+)
+
+const pingEndpoint = "/--ping"
+
+type CloudAPI struct {
+	Versions []string `json:"versions"`
+}
+
+type PingOutput struct {
+	Ping     string   `json:"ping"`
+	CloudAPI CloudAPI `json:"cloudapi"`
+}
+
+// Ping sends a request to the '/--ping' endpoint and returns a `pong` as well
+// as a list of API version numbers your instance of CloudAPI is presenting.
+func (c *ComputeClient) Ping(ctx context.Context) (*PingOutput, error) {
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   pingEndpoint,
+	}
+	response, err := c.Client.ExecuteRequestRaw(ctx, reqInputs)
+	if response == nil {
+		return nil, fmt.Errorf("Ping request has empty response")
+	}
+	if response.Body != nil {
+		defer response.Body.Close()
+	}
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
+		return nil, &client.TritonError{
+			StatusCode: response.StatusCode,
+			Code:       "ResourceNotFound",
+		}
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing Get request: {{err}}",
+			c.Client.DecodeError(response.StatusCode, response.Body))
+	}
+
+	var result *PingOutput
+	decoder := json.NewDecoder(response.Body)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding Get response: {{err}}", err)
+	}
+
+	return result, nil
+}

--- a/compute/ping_test.go
+++ b/compute/ping_test.go
@@ -1,0 +1,204 @@
+package compute_test
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/joyent/triton-go/authentication"
+	"github.com/joyent/triton-go/client"
+	"github.com/joyent/triton-go/compute"
+	"github.com/joyent/triton-go/testutils"
+)
+
+// test borked 404 response (TritonError)
+// test borked 410 response (TritonError)
+// test bad JSON decode
+
+func TestPing(t *testing.T) {
+	computeClient := buildClient()
+
+	do := func(ctx context.Context, pc *compute.ComputeClient) (*compute.PingOutput, error) {
+		defer testutils.DeactivateClient()
+
+		ping, err := pc.Ping(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return ping, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", "/--ping", pingSuccessFunc)
+
+		resp, err := do(context.Background(), computeClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Ping != "pong" {
+			t.Errorf("ping was not pong: expected %s", resp.Ping)
+		}
+
+		versions := []string{"7.0.0", "7.1.0", "7.2.0", "7.3.0", "8.0.0"}
+		if !reflect.DeepEqual(resp.CloudAPI.Versions, versions) {
+			t.Errorf("ping did not contain CloudAPI versions: expected %s", versions)
+		}
+	})
+
+	t.Run("EOF decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", "/--ping", pingEmptyFunc)
+
+		_, err := do(context.Background(), computeClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", "/--ping", pingErrorFunc)
+
+		_, err := do(context.Background(), computeClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		blankError := "Ping request has empty response"
+
+		if err.Error() != blankError {
+			t.Errorf("expected error to equal defaultError: found %s", err)
+		}
+	})
+
+	t.Run("404", func(t *testing.T) {
+		testutils.RegisterResponder("GET", "/--ping", ping404Func)
+
+		_, err := do(context.Background(), computeClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "ResourceNotFound") {
+			t.Errorf("expected error to be a 404: found %s", err)
+		}
+	})
+
+	t.Run("410", func(t *testing.T) {
+		testutils.RegisterResponder("GET", "/--ping", ping410Func)
+
+		_, err := do(context.Background(), computeClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "ResourceNotFound") {
+			t.Errorf("expected error to be a 410: found %s", err)
+		}
+	})
+
+	t.Run("bad decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", "/--ping", pingDecodeFunc)
+
+		_, err := do(context.Background(), computeClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+}
+
+var defaultError = errors.New("we got the funk")
+var defaultHeader = http.Header{}
+
+func pingSuccessFunc(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+	"ping": "pong",
+	"cloudapi": {
+		"versions": ["7.0.0", "7.1.0", "7.2.0", "7.3.0", "8.0.0"]
+	}
+}`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func pingEmptyFunc(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func ping404Func(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 404,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func ping410Func(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 410,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func pingErrorFunc(req *http.Request) (*http.Response, error) {
+	return nil, defaultError
+}
+
+func pingDecodeFunc(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+(ham!(//
+}`)
+
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func buildClient() *compute.ComputeClient {
+	testSigner, _ := authentication.NewTestSigner()
+	httpClient := &client.Client{
+		Authorizers: []authentication.Signer{testSigner},
+		HTTPClient: &http.Client{
+			Transport: testutils.DefaultMockTransport,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+	return &compute.ComputeClient{
+		Client: httpClient,
+	}
+}

--- a/testutils/mock_http.go
+++ b/testutils/mock_http.go
@@ -1,0 +1,86 @@
+package testutils
+
+import (
+	"errors"
+	"net/http"
+)
+
+// Responders are callbacks that receive http requests and return a mocked
+// response.
+type Responder func(*http.Request) (*http.Response, error)
+
+// NoResponderFound is returned when no responders are found for a given HTTP
+// method and URL.
+var NoResponderFound = errors.New("no responder found")
+
+// MockTransport implements http.RoundTripper, which fulfills single http
+// requests issued by an http.Client.  This implementation doesn't actually make
+// the call, instead defering to the registered list of responders.
+type MockTransport struct {
+	FailNoResponder bool
+	responders      map[string]Responder
+}
+
+// RoundTrip is required to implement http.MockTransport.  Instead of fulfilling
+// the given request, the internal list of responders is consulted to handle the
+// request.  If no responder is found an error is returned, which is the
+// equivalent of a network error.
+func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Method + " " + req.URL.String()
+
+	// scan through the responders and find one that matches our key
+	for k, r := range m.responders {
+		if k != key {
+			continue
+		}
+		return r(req)
+	}
+
+	// if we've been told to error when no match was found
+	if m.FailNoResponder {
+		return nil, NoResponderFound
+	}
+
+	// fallback to the default roundtripper
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// RegisterResponder adds a new responder, associated with a given HTTP method
+// and URL.  When a request comes in that matches, the responder will be called
+// and the response returned to the client.
+func (m *MockTransport) RegisterResponder(method, url string, responder Responder) {
+	m.responders[method+" "+url] = responder
+}
+
+// Clear clears out all the mock responders that have been set on a particular
+// MockTransport object. This comes in especially handy when utilizing the
+// global DefaultMockTRansport and is utilized by the DeactivateClient func.
+func (m *MockTransport) Clear() {
+	m.responders = make(map[string]Responder)
+}
+
+// DefaultMockTransport allows users to easily and globally alter the default
+// RoundTripper for all http requests.
+var DefaultMockTransport = &MockTransport{
+	responders: make(map[string]Responder),
+}
+
+// Activate replaces the `Transport` on the `http.Client` with our
+// `DefaultMockTransport`.
+func ActivateClient(failNoResponder bool) {
+	DefaultMockTransport.FailNoResponder = failNoResponder
+	http.DefaultClient.Transport = DefaultMockTransport
+}
+
+// Deactivate replaces our `DefaultMockTransport` with the
+// `http.DefaultTransport`.
+func DeactivateClient() {
+	DefaultMockTransport.Clear()
+	http.DefaultClient.Transport = http.DefaultTransport
+}
+
+// RegisterResponder adds a responder to the `DefaultMockTransport` responder
+// table.
+func RegisterResponder(method, url string, responder Responder) {
+	DefaultMockTransport.RegisterResponder(method, url, responder)
+}


### PR DESCRIPTION
This commit is part 2 of 2 for my push to introduce unit testing. It made sense to create the HTTP mock along with the new Ping endpoint functionality since it was a basic feature. The HTTP mock and setup in this PR will work across all other endpoints with minimal effort.

This PR is missing `authentication.NewTestSigner()` which is coming in a subsequent PR after this.