### PR TITLE
Add ability to manage users via triton-go

### DIFF
--- a/identity/client.go
+++ b/identity/client.go
@@ -26,8 +26,14 @@ func NewClient(config *triton.ClientConfig) (*IdentityClient, error) {
 	return newIdentityClient(client), nil
 }
 
-// Roles returns a Compute client used for accessing functions pertaining to
+// Roles returns a Roles client used for accessing functions pertaining to
 // Role functionality in the Triton API.
 func (c *IdentityClient) Roles() *RolesClient {
 	return &RolesClient{c.Client}
+}
+
+// Users returns a Users client used for accessing functions pertaining to
+// User functionality in the Triton API.
+func (c *IdentityClient) Users() *UsersClient {
+	return &UsersClient{c.Client}
 }

--- a/identity/users.go
+++ b/identity/users.go
@@ -1,0 +1,174 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/joyent/triton-go/client"
+)
+
+type UsersClient struct {
+	Client *client.Client
+}
+
+type User struct {
+	ID           string    `json:"id"`
+	Login        string    `json:"login"`
+	EmailAddress string    `json:"email"`
+	CompanyName  string    `json:"companyName"`
+	FirstName    string    `json:"firstName"`
+	LastName     string    `json:"lastName"`
+	Address      string    `json:"address"`
+	PostalCode   string    `json:"postCode"`
+	City         string    `json:"city"`
+	State        string    `json:"state"`
+	Country      string    `json:"country"`
+	Phone        string    `json:"phone"`
+	Roles        []string  `json:"roles"`
+	DefaultRoles []string  `json:"defaultRoles"`
+	CreatedAt    time.Time `json:"created"`
+	UpdatedAt    time.Time `json:"updated"`
+}
+
+type ListUsersInput struct{}
+
+func (c *UsersClient) List(ctx context.Context, _ *ListUsersInput) ([]*User, error) {
+	path := fmt.Sprintf("/%s/users", c.Client.AccountName)
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   path,
+	}
+	respReader, err := c.Client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing List request: {{err}}", err)
+	}
+
+	var result []*User
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding List response: {{err}}", err)
+	}
+
+	return result, nil
+}
+
+type GetUserInput struct {
+	UserID string
+}
+
+func (c *UsersClient) Get(ctx context.Context, input *GetUserInput) (*User, error) {
+	path := fmt.Sprintf("/%s/users/%s", c.Client.AccountName, input.UserID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   path,
+	}
+	respReader, err := c.Client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing Get request: {{err}}", err)
+	}
+
+	var result *User
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding Get response: {{err}}", err)
+	}
+
+	return result, nil
+}
+
+type DeleteUserInput struct {
+	UserID string
+}
+
+func (c *UsersClient) Delete(ctx context.Context, input *DeleteUserInput) error {
+	path := fmt.Sprintf("/%s/users/%s", c.Client.AccountName, input.UserID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodDelete,
+		Path:   path,
+	}
+	respReader, err := c.Client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return errwrap.Wrapf("Error executing Delete request: {{err}}", err)
+	}
+
+	return nil
+}
+
+type CreateUserInput struct {
+	Email       string `json:"email"`
+	Login       string `json:"login"`
+	Password    string `json:"password"`
+	CompanyName string `json:"companyName,omitempty"`
+	FirstName   string `json:"firstName,omitempty"`
+	LastName    string `json:"lastName,omitempty"`
+	Address     string `json:"address,omitempty"`
+	PostalCode  string `json:"postalCode,omitempty"`
+	City        string `json:"city,omitempty"`
+	State       string `json:"state,omitempty"`
+	Country     string `json:"country,omitempty"`
+	Phone       string `json:"phone,omitempty"`
+}
+
+func (c *UsersClient) Create(ctx context.Context, input *CreateUserInput) error {
+	path := fmt.Sprintf("/%s/users", c.Client.AccountName)
+	reqInputs := client.RequestInput{
+		Method: http.MethodPost,
+		Path:   path,
+		Body:   input,
+	}
+	respReader, err := c.Client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return errwrap.Wrapf("Error executing Create request: {{err}}", err)
+	}
+
+	return nil
+}
+
+type UpdateUserInput struct {
+	UserID      string
+	Email       string `json:"email,omitempty"`
+	Login       string `json:"login,omitempty"`
+	CompanyName string `json:"companyName,omitempty"`
+	FirstName   string `json:"firstName,omitempty"`
+	LastName    string `json:"lastName,omitempty"`
+	Address     string `json:"address,omitempty"`
+	PostalCode  string `json:"postalCode,omitempty"`
+	City        string `json:"city,omitempty"`
+	State       string `json:"state,omitempty"`
+	Country     string `json:"country,omitempty"`
+	Phone       string `json:"phone,omitempty"`
+}
+
+func (c *UsersClient) Update(ctx context.Context, input *UpdateUserInput) error {
+	path := fmt.Sprintf("/%s/users/%s", c.Client.AccountName, input.UserID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodPost,
+		Path:   path,
+		Body:   input,
+	}
+	respReader, err := c.Client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return errwrap.Wrapf("Error executing Create request: {{err}}", err)
+	}
+
+	return nil
+}

--- a/identity/users_test.go
+++ b/identity/users_test.go
@@ -1,0 +1,481 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/joyent/triton-go/identity"
+	"github.com/joyent/triton-go/testutils"
+)
+
+const accountUrl = "testing"
+
+var (
+	listUserErrorType   = errors.New("Error executing List request:")
+	getUserErrorType    = errors.New("Error executing Get request:")
+	deleteUserErrorType = errors.New("Error executing Delete request:")
+	createUserErrorType = errors.New("Error executing Create request:")
+	updateUserErrorType = errors.New("Error executing Update request:")
+)
+
+func MockIdentityClient() *identity.IdentityClient {
+	return &identity.IdentityClient{
+		Client: testutils.NewMockClient(testutils.MockClientInput{
+			AccountName: accountUrl,
+		}),
+	}
+}
+
+func TestListUsers(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) ([]*identity.User, error) {
+		defer testutils.DeactivateClient()
+
+		ping, err := ic.Users().List(ctx, &identity.ListUsersInput{})
+		if err != nil {
+			return nil, err
+		}
+		return ping, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users", accountUrl), listUsersSuccess)
+
+		resp, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users", accountUrl), listUsersEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users", accountUrl), listUsersBadeDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users", accountUrl), listUserError)
+
+		resp, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Error("expected resp to be nil")
+		}
+
+		if !strings.Contains(err.Error(), "Error executing List request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestGetUser(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.User, error) {
+		defer testutils.DeactivateClient()
+
+		user, err := ic.Users().Get(ctx, &identity.GetUserInput{
+			UserID: "123-3456-2335",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return user, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users/%s", accountUrl, "123-3456-2335"), getUserSuccess)
+
+		resp, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users/%s", accountUrl, "123-3456-2335"), getUserEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users/%s", accountUrl, "123-3456-2335"), getUserBadeDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/users", accountUrl), getUserError)
+
+		resp, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Error("expected resp to be nil")
+		}
+
+		if !strings.Contains(err.Error(), "Error executing Get request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestDeleteUser(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) error {
+		defer testutils.DeactivateClient()
+
+		return ic.Users().Delete(ctx, &identity.DeleteUserInput{
+			UserID: "123-3456-2335",
+		})
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("DELETE", fmt.Sprintf("/%s/users/%s", accountUrl, "123-3456-2335"), deleteUserSuccess)
+
+		err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("DELETE", fmt.Sprintf("/%s/users", accountUrl), deleteUserError)
+
+		err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "Error executing Delete request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestCreateUser(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) error {
+		defer testutils.DeactivateClient()
+
+		return ic.Users().Create(ctx, &identity.CreateUserInput{
+			Email:    "fake@fake.com",
+			Login:    "testuser",
+			Password: "Password123",
+		})
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/users", accountUrl), createUserSuccess)
+
+		err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/users", accountUrl), createUserError)
+
+		err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "Error executing Create request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestUpdateUser(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) error {
+		defer testutils.DeactivateClient()
+
+		return ic.Users().Update(ctx, &identity.UpdateUserInput{
+			UserID: "123-3456-2335",
+			Login:  "testuser1",
+		})
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/users/%s", accountUrl, "123-3456-2335"), updateUserSuccess)
+
+		err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/users/%s", accountUrl, "123-3456-2335"), updateUserError)
+
+		err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "Error executing Update request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func getUserSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "id": "4fc13ac6-1e7d-cd79-f3d2-96276af0d638",
+    "login": "barbar",
+    "email": "barbar@example.com",
+    "companyName": "Example",
+    "firstName": "BarBar",
+    "lastName": "Jinks",
+    "phone": "(123)457-6890",
+    "updated": "2015-12-23T06:41:11.032Z",
+    "created": "2015-12-23T06:41:11.032Z"
+  }
+`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func getUserError(req *http.Request) (*http.Response, error) {
+	return nil, getUserErrorType
+}
+
+func getUserBadeDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "id": "4fc13ac6-1e7d-cd79-f3d2-96276af0d638",
+    "login": "barbar",
+    "email": "barbar@example.com",
+    "companyName": "Example",
+    "firstName": "BarBar",
+    "lastName": "Jinks",
+    "phone": "(123)457-6890",
+    "updated": "2015-12-23T06:41:11.032Z",
+    "created": "2015-12-23T06:41:11.032Z",}`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func getUserEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func listUsersEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func listUsersSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`[
+	{
+    "id": "4fc13ac6-1e7d-cd79-f3d2-96276af0d638",
+    "login": "barbar",
+    "email": "barbar@example.com",
+    "companyName": "Example",
+    "firstName": "BarBar",
+    "lastName": "Jinks",
+    "phone": "(123)457-6890",
+    "updated": "2015-12-23T06:41:11.032Z",
+    "created": "2015-12-23T06:41:11.032Z"
+  },
+  {
+    "id": "332ce629-fcc5-45c3-e34f-e7cfbeab1327",
+    "login": "san",
+    "email": "san@example.com",
+    "companyName": "Example Inc",
+    "firstName": "San",
+    "lastName": "Holo",
+    "phone": "(123)456-0987",
+    "updated": "2015-12-23T06:41:56.102Z",
+    "created": "2015-12-23T06:41:56.102Z"
+  }
+]`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func listUsersBadeDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{[
+	{
+    "id": "4fc13ac6-1e7d-cd79-f3d2-96276af0d638",
+    "login": "barbar",
+    "email": "barbar@example.com",
+    "companyName": "Example",
+    "firstName": "BarBar",
+    "lastName": "Jinks",
+    "phone": "(123)457-6890",
+    "updated": "2015-12-23T06:41:11.032Z",
+    "created": "2015-12-23T06:41:11.032Z"
+  },
+  {
+    "id": "332ce629-fcc5-45c3-e34f-e7cfbeab1327",
+    "login": "san",
+    "email": "san@example.com",
+    "companyName": "Example Inc",
+    "firstName": "San",
+    "lastName": "Holo",
+    "phone": "(123)456-0987",
+    "updated": "2015-12-23T06:41:56.102Z",
+    "created": "2015-12-23T06:41:56.102Z"
+  }
+]}`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func listUserError(req *http.Request) (*http.Response, error) {
+	return nil, listUserErrorType
+}
+
+func deleteUserSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: 204,
+		Header:     header,
+	}, nil
+}
+
+func deleteUserError(req *http.Request) (*http.Response, error) {
+	return nil, deleteUserErrorType
+}
+
+func createUserSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "id": "123-3456-2335",
+    "login": "testuser",
+    "email": "barbar@example.com",
+    "updated": "2015-12-23T06:41:11.032Z",
+    "created": "2015-12-23T06:41:11.032Z"
+  }
+`)
+
+	return &http.Response{
+		StatusCode: 201,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func createUserError(req *http.Request) (*http.Response, error) {
+	return nil, createUserErrorType
+}
+
+func updateUserSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "id": "123-3456-2335",
+    "login": "testuser",
+    "email": "barbar@example.com",
+    "updated": "2015-12-23T06:41:11.032Z",
+    "created": "2015-12-23T06:41:11.032Z"
+  }
+`)
+
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func updateUserError(req *http.Request) (*http.Response, error) {
+	return nil, updateUserErrorType
+}

--- a/testutils/mock_http.go
+++ b/testutils/mock_http.go
@@ -89,12 +89,16 @@ func RegisterResponder(method, url string, responder Responder) {
 }
 
 // DefaultMockClient uses NewMockClient to construct a mocked out client.Client
-var DefaultMockClient = NewMockClient()
+var DefaultMockClient = NewMockClient(MockClientInput{})
+
+type MockClientInput struct {
+	AccountName string
+}
 
 // NewMockClient returns a new client.Client that includes our
 // DefaultMockTransport which allows us to attach custom HTTP client request
 // responders.
-func NewMockClient() *client.Client {
+func NewMockClient(input MockClientInput) *client.Client {
 	testSigner, _ := authentication.NewTestSigner()
 
 	httpClient := &http.Client{
@@ -104,8 +108,14 @@ func NewMockClient() *client.Client {
 		},
 	}
 
-	return &client.Client{
+	client := &client.Client{
 		Authorizers: []authentication.Signer{testSigner},
 		HTTPClient:  httpClient,
 	}
+
+	if input.AccountName != "" {
+		client.AccountName = input.AccountName
+	}
+
+	return client
 }


### PR DESCRIPTION
This adds all of the Users endpoints except `ChangePassword` right now

@cheapRoc thoughts on this please? I wasn't sure how to test this easily as it actually creates and deletes accounts