### PR TITLE
Enable HTTP Keepalives for the Triton client.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -128,8 +128,8 @@ func httpTransport(insecureSkipTLSVerify bool) *http.Transport {
 			KeepAlive: 30 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
-		DisableKeepAlives:   true,
-		MaxIdleConnsPerHost: -1,
+		MaxIdleConns:        10,
+		IdleConnTimeout:     15 * time.Second,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: insecureSkipTLSVerify,
 		},


### PR DESCRIPTION
The new defaults are:

1) Allow HTTP KeepAlives
2) 15sec idle timeout per connection
3) 2x connections per host
4) Default max of 10x connections total for the HTTP client

The idle timeout could be made more aggressive if necessary (e.g. 5s)
but 15s seems like a reasonable default.