### PR TITLE
Use path.Join() and path.Clean() when constructing object paths.

### DIFF
--- a/storage/directory.go
+++ b/storage/directory.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"time"
 
@@ -42,7 +42,7 @@ type ListDirectoryOutput struct {
 
 // List lists the contents of a directory on the Triton Object Store service.
 func (s *DirectoryClient) List(ctx context.Context, input *ListDirectoryInput) (*ListDirectoryOutput, error) {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.DirectoryName)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.DirectoryName))
 	query := &url.Values{}
 	if input.Limit != 0 {
 		query.Set("limit", strconv.FormatUint(input.Limit, 10))
@@ -53,7 +53,7 @@ func (s *DirectoryClient) List(ctx context.Context, input *ListDirectoryInput) (
 
 	reqInput := client.RequestInput{
 		Method: http.MethodGet,
-		Path:   path,
+		Path:   fullPath,
 		Query:  query,
 	}
 	respBody, respHeader, err := s.client.ExecuteRequestStorage(ctx, reqInput)
@@ -98,13 +98,13 @@ type PutDirectoryInput struct {
 // create-or-update operation. Your private namespace starts at /:login, and you
 // can create any nested set of directories or objects within it.
 func (s *DirectoryClient) Put(ctx context.Context, input *PutDirectoryInput) error {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.DirectoryName)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.DirectoryName))
 	headers := &http.Header{}
 	headers.Set("Content-Type", "application/json; type=directory")
 
 	reqInput := client.RequestInput{
 		Method:  http.MethodPut,
-		Path:    path,
+		Path:    fullPath,
 		Headers: headers,
 	}
 	respBody, _, err := s.client.ExecuteRequestStorage(ctx, reqInput)
@@ -126,11 +126,11 @@ type DeleteDirectoryInput struct {
 // Delete deletes a directory on the Triton Object Storage. The directory must
 // be empty.
 func (s *DirectoryClient) Delete(ctx context.Context, input *DeleteDirectoryInput) error {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.DirectoryName)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.DirectoryName))
 
 	reqInput := client.RequestInput{
 		Method: http.MethodDelete,
-		Path:   path,
+		Path:   fullPath,
 	}
 	respBody, _, err := s.client.ExecuteRequestStorage(ctx, reqInput)
 	if respBody != nil {

--- a/storage/directory.go
+++ b/storage/directory.go
@@ -27,14 +27,14 @@ type DirectoryEntry struct {
 	Type         string    `json:"type"`
 }
 
-// ListDirectoryInput represents parameters to a ListDirectory operation.
+// ListDirectoryInput represents parameters to a List operation.
 type ListDirectoryInput struct {
 	DirectoryName string
 	Limit         uint64
 	Marker        string
 }
 
-// ListDirectoryOutput contains the outputs of a ListDirectory operation.
+// ListDirectoryOutput contains the outputs of a List operation.
 type ListDirectoryOutput struct {
 	Entries       []*DirectoryEntry
 	ResultSetSize uint64
@@ -61,7 +61,7 @@ func (s *DirectoryClient) List(ctx context.Context, input *ListDirectoryInput) (
 		defer respBody.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing ListDirectory request: {{err}}", err)
+		return nil, errwrap.Wrapf("Error executing List request: {{err}}", err)
 	}
 
 	var results []*DirectoryEntry
@@ -72,7 +72,7 @@ func (s *DirectoryClient) List(ctx context.Context, input *ListDirectoryInput) (
 			if err == io.EOF {
 				break
 			}
-			return nil, errwrap.Wrapf("Error decoding ListDirectory response: {{err}}", err)
+			return nil, errwrap.Wrapf("Error decoding List response: {{err}}", err)
 		}
 		results = append(results, current)
 	}
@@ -89,7 +89,7 @@ func (s *DirectoryClient) List(ctx context.Context, input *ListDirectoryInput) (
 	return output, nil
 }
 
-// PutDirectoryInput represents parameters to a PutDirectory operation.
+// PutDirectoryInput represents parameters to a Put operation.
 type PutDirectoryInput struct {
 	DirectoryName string
 }
@@ -112,13 +112,13 @@ func (s *DirectoryClient) Put(ctx context.Context, input *PutDirectoryInput) err
 		defer respBody.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing PutDirectory request: {{err}}", err)
+		return errwrap.Wrapf("Error executing Put request: {{err}}", err)
 	}
 
 	return nil
 }
 
-// DeleteDirectoryInput represents parameters to a DeleteDirectory operation.
+// DeleteDirectoryInput represents parameters to a Delete operation.
 type DeleteDirectoryInput struct {
 	DirectoryName string
 }
@@ -137,7 +137,7 @@ func (s *DirectoryClient) Delete(ctx context.Context, input *DeleteDirectoryInpu
 		defer respBody.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing DeleteDirectory request: {{err}}", err)
+		return errwrap.Wrapf("Error executing Delete request: {{err}}", err)
 	}
 
 	return nil

--- a/storage/objects.go
+++ b/storage/objects.go
@@ -55,7 +55,7 @@ func (s *ObjectsClient) Get(ctx context.Context, input *GetObjectInput) (*GetObj
 	}
 	respBody, respHeaders, err := s.client.ExecuteRequestStorage(ctx, reqInput)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing GetDirectory request: {{err}}", err)
+		return nil, errwrap.Wrapf("Error executing Get request: {{err}}", err)
 	}
 
 	response := &GetObjectOutput{
@@ -111,7 +111,7 @@ func (s *ObjectsClient) Delete(ctx context.Context, input *DeleteObjectInput) er
 		defer respBody.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing DeleteObject request: {{err}}", err)
+		return errwrap.Wrapf("Error executing Delete request: {{err}}", err)
 	}
 
 	return nil
@@ -155,7 +155,7 @@ func (s *ObjectsClient) PutMetadata(ctx context.Context, input *PutObjectMetadat
 		defer respBody.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing PutObjectMetadata request: {{err}}", err)
+		return errwrap.Wrapf("Error executing PutMetadata request: {{err}}", err)
 	}
 
 	return nil
@@ -219,7 +219,7 @@ func (s *ObjectsClient) Put(ctx context.Context, input *PutObjectInput) error {
 		defer respBody.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing PutObjectMetadata request: {{err}}", err)
+		return errwrap.Wrapf("Error executing Put request: {{err}}", err)
 	}
 
 	return nil

--- a/storage/objects.go
+++ b/storage/objects.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -41,7 +41,7 @@ type GetObjectOutput struct {
 // call returns successfully), it is your responsibility to close the
 // io.ReadCloser named ObjectReader in the operation output.
 func (s *ObjectsClient) Get(ctx context.Context, input *GetObjectInput) (*GetObjectOutput, error) {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.ObjectPath)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.ObjectPath))
 
 	headers := &http.Header{}
 	for key, value := range input.Headers {
@@ -50,7 +50,7 @@ func (s *ObjectsClient) Get(ctx context.Context, input *GetObjectInput) (*GetObj
 
 	reqInput := client.RequestInput{
 		Method:  http.MethodGet,
-		Path:    path,
+		Path:    fullPath,
 		Headers: headers,
 	}
 	respBody, respHeaders, err := s.client.ExecuteRequestStorage(ctx, reqInput)
@@ -94,7 +94,7 @@ type DeleteObjectInput struct {
 
 // DeleteObject deletes an object.
 func (s *ObjectsClient) Delete(ctx context.Context, input *DeleteObjectInput) error {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.ObjectPath)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.ObjectPath))
 
 	headers := &http.Header{}
 	for key, value := range input.Headers {
@@ -103,7 +103,7 @@ func (s *ObjectsClient) Delete(ctx context.Context, input *DeleteObjectInput) er
 
 	reqInput := client.RequestInput{
 		Method:  http.MethodDelete,
-		Path:    path,
+		Path:    fullPath,
 		Headers: headers,
 	}
 	respBody, _, err := s.client.ExecuteRequestStorage(ctx, reqInput)
@@ -134,7 +134,7 @@ type PutObjectMetadataInput struct {
 //	- Content-MD5
 //	- Durability-Level
 func (s *ObjectsClient) PutMetadata(ctx context.Context, input *PutObjectMetadataInput) error {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.ObjectPath)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.ObjectPath))
 	query := &url.Values{}
 	query.Set("metadata", "true")
 
@@ -146,7 +146,7 @@ func (s *ObjectsClient) PutMetadata(ctx context.Context, input *PutObjectMetadat
 
 	reqInput := client.RequestInput{
 		Method:  http.MethodPut,
-		Path:    path,
+		Path:    fullPath,
 		Query:   query,
 		Headers: headers,
 	}
@@ -176,7 +176,7 @@ type PutObjectInput struct {
 }
 
 func (s *ObjectsClient) Put(ctx context.Context, input *PutObjectInput) error {
-	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.ObjectPath)
+	fullPath := path.Clean(path.Join("/", s.client.AccountName, input.ObjectPath))
 
 	if input.MaxContentLength != 0 && input.ContentLength != 0 {
 		return errors.New("ContentLength and MaxContentLength may not both be set to non-zero values.")
@@ -210,7 +210,7 @@ func (s *ObjectsClient) Put(ctx context.Context, input *PutObjectInput) error {
 
 	reqInput := client.RequestNoEncodeInput{
 		Method:  http.MethodPut,
-		Path:    path,
+		Path:    fullPath,
 		Headers: headers,
 		Body:    input.ObjectReader,
 	}

--- a/storage/objects.go
+++ b/storage/objects.go
@@ -37,9 +37,9 @@ type GetObjectOutput struct {
 	ObjectReader  io.ReadCloser
 }
 
-// GetObject retrieves an object from the Manta service. If error is nil (i.e.
-// the call returns successfully), it is your responsibility to close the io.ReadCloser
-// named ObjectReader in the operation output.
+// Get retrieves an object from the Manta service. If error is nil (i.e. the
+// call returns successfully), it is your responsibility to close the
+// io.ReadCloser named ObjectReader in the operation output.
 func (s *ObjectsClient) Get(ctx context.Context, input *GetObjectInput) (*GetObjectOutput, error) {
 	path := fmt.Sprintf("/%s%s", s.client.AccountName, input.ObjectPath)
 


### PR DESCRIPTION
Use of `fmt.Sprintf()` was bothering my sense of aesthetics.  This should be faster and a tad more reliable.

Also fixed up some comments while here.