### PR TITLE
Move readers from an `io.ReadSeaker` to an `io.Reader`.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -174,7 +174,7 @@ func (c *Client) ExecuteRequestURIParams(ctx context.Context, inputs RequestInpu
 	body := inputs.Body
 	query := inputs.Query
 
-	var requestBody io.ReadSeeker
+	var requestBody io.Reader
 	if body != nil {
 		marshaled, err := json.MarshalIndent(body, "", "    ")
 		if err != nil {
@@ -233,7 +233,7 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 	path := inputs.Path
 	body := inputs.Body
 
-	var requestBody io.ReadSeeker
+	var requestBody io.Reader
 	if body != nil {
 		marshaled, err := json.MarshalIndent(body, "", "    ")
 		if err != nil {
@@ -286,7 +286,7 @@ func (c *Client) ExecuteRequestStorage(ctx context.Context, inputs RequestInput)
 	endpoint := c.MantaURL
 	endpoint.Path = path
 
-	var requestBody io.ReadSeeker
+	var requestBody io.Reader
 	if body != nil {
 		marshaled, err := json.MarshalIndent(body, "", "    ")
 		if err != nil {
@@ -351,7 +351,7 @@ type RequestNoEncodeInput struct {
 	Path    string
 	Query   *url.Values
 	Headers *http.Header
-	Body    io.ReadSeeker
+	Body    io.Reader
 }
 
 func (c *Client) ExecuteRequestNoEncode(ctx context.Context, inputs RequestNoEncodeInput) (io.ReadCloser, http.Header, error) {

--- a/storage/objects.go
+++ b/storage/objects.go
@@ -34,7 +34,7 @@ type GetObjectOutput struct {
 	ContentMD5    string
 	ETag          string
 	Metadata      map[string]string
-	ObjectReader  io.ReadCloser
+	ObjectReader  io.Reader
 }
 
 // Get retrieves an object from the Manta service. If error is nil (i.e. the
@@ -171,7 +171,7 @@ type PutObjectInput struct {
 	IfModifiedSince  *time.Time
 	ContentLength    uint64
 	MaxContentLength uint64
-	ObjectReader     io.ReadSeeker
+	ObjectReader     io.Reader
 	Headers          map[string]string
 }
 


### PR DESCRIPTION
When `triton-go` used a retriable HTTP client, it was required to use an `io.ReadSeaker`.  Now that `triton-go` doesn't use retriablehttp, relax this requirement to be just an `io.Reader`.  In the future we may revisit this and re-introduce a retriable client and promote this to an `io.ReadSeaker`, or figure out another way of passing in a Seaker.  The reason for wanting to do this is now you can read from a pipe (i.e. stdin).

This change is forward compatible.  Going back to an `io.ReadSeaker` will be backwards incompatible for people using non-seakable readers and will require additional thought.

Changelog entry: required