### PR TITLE
resource/machine: Prevent panic when no network connection

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -97,10 +97,13 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 		Path:   path,
 	}
 	response, err := c.client.ExecuteRequestRaw(ctx, reqInputs)
-	if response != nil {
+	if response == nil {
+		return nil, errwrap.Wrapf("Error executing Get request: {{err}}", err)
+	}
+	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	if response == nil || response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",


### PR DESCRIPTION
When a network connection dropped on a GET request for an instance, a panic was thrown as follows:

```
panic: runtime error: invalid memory address or nil pointer dereference
2017-12-22T15:28:53.217+0200 [DEBUG] plugin.terraform-provider-triton_v0.3.0_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x15b7f95]
2017-12-22T15:28:53.217+0200 [DEBUG] plugin.terraform-provider-triton_v0.3.0_x4:
2017-12-22T15:28:53.217+0200 [DEBUG] plugin.terraform-provider-triton_v0.3.0_x4: goroutine 89 [running]:
2017-12-22T15:28:53.217+0200 [DEBUG] plugin.terraform-provider-triton_v0.3.0_x4: github.com/terraform-providers/terraform-provider-triton/vendor/github.com/joyent/triton-go/compute.(*InstancesClient).Get(0xc4202959b8, 0x1b94160, 0xc4200160c0, 0xc4202ac9c0, 0x0, 0x0, 0x0)
2017-12-22T15:28:53.217+0200 [DEBUG] plugin.terraform-provider-triton_v0.3.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-triton/vendor/github.com/joyent/triton-go/compute/instances.go:105 +0x245
```

We now guard against this to make sure that the user doesn't see the unexpected behaviour:

```
* module.bastion.triton_machine.bastion: triton_machine.bastion: Error executing Get request: Error executing HTTP request: Get https://us-sw-1.api.joyentcloud.com/stack72_joyent/machines/c3503968-998c-6e6c-d866-b1a797bab71c: net/http: TLS handshake timeout
```