### PR TITLE
identity/policies: Add support for managing policies in Triton

### DIFF
--- a/identity/client.go
+++ b/identity/client.go
@@ -37,3 +37,9 @@ func (c *IdentityClient) Roles() *RolesClient {
 func (c *IdentityClient) Users() *UsersClient {
 	return &UsersClient{c.Client}
 }
+
+// Policies returns a Policies client used for accessing functions pertaining to
+// Policy functionality in the Triton API.
+func (c *IdentityClient) Policies() *PoliciesClient {
+	return &PoliciesClient{c.Client}
+}

--- a/identity/policies.go
+++ b/identity/policies.go
@@ -1,0 +1,158 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/joyent/triton-go/client"
+)
+
+type PoliciesClient struct {
+	client *client.Client
+}
+
+type Policy struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Rules       []string `json:"rules"`
+	Description string   `json:"description"`
+}
+
+type ListPoliciesInput struct{}
+
+func (c *PoliciesClient) List(ctx context.Context, _ *ListPoliciesInput) ([]*Policy, error) {
+	path := fmt.Sprintf("/%s/policies", c.client.AccountName)
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   path,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing ListPolicies request: {{err}}", err)
+	}
+
+	var result []*Policy
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding ListPolicies response: {{err}}", err)
+	}
+
+	return result, nil
+}
+
+type GetPolicyInput struct {
+	PolicyID string
+}
+
+func (c *PoliciesClient) Get(ctx context.Context, input *GetPolicyInput) (*Policy, error) {
+	path := fmt.Sprintf("/%s/policies/%s", c.client.AccountName, input.PolicyID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   path,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing GetPolicy request: {{err}}", err)
+	}
+
+	var result *Policy
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding GetPolicy response: {{err}}", err)
+	}
+
+	return result, nil
+}
+
+type DeletePolicyInput struct {
+	PolicyID string
+}
+
+func (c *PoliciesClient) Delete(ctx context.Context, input *DeletePolicyInput) error {
+	path := fmt.Sprintf("/%s/policies/%s", c.client.AccountName, input.PolicyID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodDelete,
+		Path:   path,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return errwrap.Wrapf("Error executing DeletePolicy request: {{err}}", err)
+	}
+
+	return nil
+}
+
+// UpdatePolicyInput represents the options that can be specified
+// when updating a policy. Anything but ID can be modified.
+type UpdatePolicyInput struct {
+	PolicyID    string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Rules       []string `json:"rules,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+func (c *PoliciesClient) Update(ctx context.Context, input *UpdatePolicyInput) (*Policy, error) {
+	path := fmt.Sprintf("/%s/policies/%s", c.client.AccountName, input.PolicyID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodPost,
+		Path:   path,
+		Body:   input,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing UpdatePolicy request: {{err}}", err)
+	}
+
+	var result *Policy
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding UpdatePolicy response: {{err}}", err)
+	}
+
+	return result, nil
+}
+
+type CreatePolicyInput struct {
+	Name        string   `json:"name"`
+	Rules       []string `json:"rules"`
+	Description string   `json:"description,omitempty"`
+}
+
+func (c *PoliciesClient) Create(ctx context.Context, input *CreatePolicyInput) (*Policy, error) {
+	path := fmt.Sprintf("/%s/policies", c.client.AccountName)
+	reqInputs := client.RequestInput{
+		Method: http.MethodPost,
+		Path:   path,
+		Body:   input,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errwrap.Wrapf("Error executing CreatePolicy request: {{err}}", err)
+	}
+
+	var result *Policy
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errwrap.Wrapf("Error decoding CreatePolicy response: {{err}}", err)
+	}
+
+	return result, nil
+}

--- a/identity/policies.go
+++ b/identity/policies.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/joyent/triton-go/client"
+	"github.com/pkg/errors"
 )
 
 type PoliciesClient struct {
@@ -34,13 +34,13 @@ func (c *PoliciesClient) List(ctx context.Context, _ *ListPoliciesInput) ([]*Pol
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing ListPolicies request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to list policies")
 	}
 
 	var result []*Policy
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding ListPolicies response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode list policies response")
 	}
 
 	return result, nil
@@ -61,13 +61,13 @@ func (c *PoliciesClient) Get(ctx context.Context, input *GetPolicyInput) (*Polic
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing GetPolicy request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to get policy")
 	}
 
 	var result *Policy
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding GetPolicy response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode get policy response")
 	}
 
 	return result, nil
@@ -88,7 +88,7 @@ func (c *PoliciesClient) Delete(ctx context.Context, input *DeletePolicyInput) e
 		defer respReader.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing DeletePolicy request: {{err}}", err)
+		return errors.Wrap(err, "unable to delete policy")
 	}
 
 	return nil
@@ -115,13 +115,13 @@ func (c *PoliciesClient) Update(ctx context.Context, input *UpdatePolicyInput) (
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing UpdatePolicy request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to update policy")
 	}
 
 	var result *Policy
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding UpdatePolicy response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode update policy response")
 	}
 
 	return result, nil
@@ -145,13 +145,13 @@ func (c *PoliciesClient) Create(ctx context.Context, input *CreatePolicyInput) (
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing CreatePolicy request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to create policy")
 	}
 
 	var result *Policy
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding CreatePolicy response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode create policy response")
 	}
 
 	return result, nil

--- a/identity/policies.go
+++ b/identity/policies.go
@@ -3,8 +3,9 @@ package identity
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
+
+	"path"
 
 	"github.com/joyent/triton-go/client"
 	"github.com/pkg/errors"
@@ -24,17 +25,17 @@ type Policy struct {
 type ListPoliciesInput struct{}
 
 func (c *PoliciesClient) List(ctx context.Context, _ *ListPoliciesInput) ([]*Policy, error) {
-	path := fmt.Sprintf("/%s/policies", c.client.AccountName)
+	fullPath := path.Join("/", c.client.AccountName, "policies")
 	reqInputs := client.RequestInput{
 		Method: http.MethodGet,
-		Path:   path,
+		Path:   fullPath,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
-	if respReader != nil {
-		defer respReader.Close()
-	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list policies")
+	}
+	if respReader != nil {
+		defer respReader.Close()
 	}
 
 	var result []*Policy
@@ -51,17 +52,17 @@ type GetPolicyInput struct {
 }
 
 func (c *PoliciesClient) Get(ctx context.Context, input *GetPolicyInput) (*Policy, error) {
-	path := fmt.Sprintf("/%s/policies/%s", c.client.AccountName, input.PolicyID)
+	fullPath := path.Join("/", c.client.AccountName, "policies", input.PolicyID)
 	reqInputs := client.RequestInput{
 		Method: http.MethodGet,
-		Path:   path,
+		Path:   fullPath,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
-	if respReader != nil {
-		defer respReader.Close()
-	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get policy")
+	}
+	if respReader != nil {
+		defer respReader.Close()
 	}
 
 	var result *Policy
@@ -78,17 +79,17 @@ type DeletePolicyInput struct {
 }
 
 func (c *PoliciesClient) Delete(ctx context.Context, input *DeletePolicyInput) error {
-	path := fmt.Sprintf("/%s/policies/%s", c.client.AccountName, input.PolicyID)
+	fullPath := path.Join("/", c.client.AccountName, "policies", input.PolicyID)
 	reqInputs := client.RequestInput{
 		Method: http.MethodDelete,
-		Path:   path,
+		Path:   fullPath,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
-	if respReader != nil {
-		defer respReader.Close()
-	}
 	if err != nil {
 		return errors.Wrap(err, "unable to delete policy")
+	}
+	if respReader != nil {
+		defer respReader.Close()
 	}
 
 	return nil
@@ -104,18 +105,18 @@ type UpdatePolicyInput struct {
 }
 
 func (c *PoliciesClient) Update(ctx context.Context, input *UpdatePolicyInput) (*Policy, error) {
-	path := fmt.Sprintf("/%s/policies/%s", c.client.AccountName, input.PolicyID)
+	fullPath := path.Join("/", c.client.AccountName, "policies", input.PolicyID)
 	reqInputs := client.RequestInput{
 		Method: http.MethodPost,
-		Path:   path,
+		Path:   fullPath,
 		Body:   input,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
-	if respReader != nil {
-		defer respReader.Close()
-	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update policy")
+	}
+	if respReader != nil {
+		defer respReader.Close()
 	}
 
 	var result *Policy
@@ -134,18 +135,18 @@ type CreatePolicyInput struct {
 }
 
 func (c *PoliciesClient) Create(ctx context.Context, input *CreatePolicyInput) (*Policy, error) {
-	path := fmt.Sprintf("/%s/policies", c.client.AccountName)
+	fullPath := path.Join("/", c.client.AccountName, "policies")
 	reqInputs := client.RequestInput{
 		Method: http.MethodPost,
-		Path:   path,
+		Path:   fullPath,
 		Body:   input,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
-	if respReader != nil {
-		defer respReader.Close()
-	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create policy")
+	}
+	if respReader != nil {
+		defer respReader.Close()
 	}
 
 	var result *Policy

--- a/identity/policies_test.go
+++ b/identity/policies_test.go
@@ -1,0 +1,453 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/joyent/triton-go/identity"
+	"github.com/joyent/triton-go/testutils"
+)
+
+var (
+	listPoliciesErrorType = errors.New("Error executing ListPolicies request:")
+	getPolicyErrorType    = errors.New("Error executing GetPolicy request:")
+	deletePolicyErrorType = errors.New("Error executing DeletePolicy request:")
+	updatePolicyErrorType = errors.New("Error executing UpdatePolicy request:")
+	createPolicyErrorType = errors.New("Error executing CreatePolicy request:")
+)
+
+func TestListPolicies(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) ([]*identity.Policy, error) {
+		defer testutils.DeactivateClient()
+
+		policies, err := ic.Policies().List(ctx, &identity.ListPoliciesInput{})
+		if err != nil {
+			return nil, err
+		}
+		return policies, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies", accountUrl), listPoliciesSuccess)
+
+		resp, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies", accountUrl), listPoliciesEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies", accountUrl), listPoliciesBadeDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies", accountUrl), listPoliciesError)
+
+		resp, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Error("expected resp to be nil")
+		}
+
+		if !strings.Contains(err.Error(), "Error executing ListPolicies request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestGetPolicy(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Policy, error) {
+		defer testutils.DeactivateClient()
+
+		user, err := ic.Policies().Get(ctx, &identity.GetPolicyInput{
+			PolicyID: "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return user, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), getPolicySuccess)
+
+		resp, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), getPolicyEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), getPolicyBadeDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies", accountUrl), getPolicyError)
+
+		resp, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Error("expected resp to be nil")
+		}
+
+		if !strings.Contains(err.Error(), "Error executing GetPolicy request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestDeletePolicy(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) error {
+		defer testutils.DeactivateClient()
+
+		return ic.Policies().Delete(ctx, &identity.DeletePolicyInput{
+			PolicyID: "8700e959-4cb3-4337-8afa-fb0a53b5366e",
+		})
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("DELETE", fmt.Sprintf("/%s/policies/%s", accountUrl, "8700e959-4cb3-4337-8afa-fb0a53b5366e"), deletePolicySuccess)
+
+		err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("DELETE", fmt.Sprintf("/%s/policies", accountUrl), deletePolicyError)
+
+		err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "Error executing DeletePolicy request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestUpdatePolicy(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Policy, error) {
+		defer testutils.DeactivateClient()
+
+		policy, err := ic.Policies().Update(ctx, &identity.UpdatePolicyInput{
+			PolicyID:    "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+			Description: "Updated Description",
+			Name:        "Updated Name",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return policy, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), updatePolicySuccess)
+
+		_, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), updatePolicyError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "Error executing UpdatePolicy request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestCreatePolocy(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Policy, error) {
+		defer testutils.DeactivateClient()
+
+		policy, err := ic.Policies().Create(ctx, &identity.CreatePolicyInput{
+			Name:        "Test Policy",
+			Description: "Test Description",
+			Rules:       []string{"CAN rebootmachine"},
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		return policy, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies", accountUrl), createPolicySuccess)
+
+		_, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies", accountUrl), createPolicyError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "Error executing CreatePolicy request:") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func listPoliciesEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func listPoliciesSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`[
+	{
+    "name": "readinstance",
+    "id": "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+    "rules": [
+      "can listmachine and getmachine"
+    ]
+  },
+  {
+    "name": "createinstance",
+    "id": "95ca7b25-5c8f-4c1b-92da-4276f23805ds",
+    "rules": [
+      "can createinstance"
+    ]
+  }
+]`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func listPoliciesBadeDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{[
+	{
+    "name": "createinstance",
+    "id": "95ca7b25-5c8f-4c1b-92da-4276f23805ds",
+    "rules": [
+      "can createinstance"
+    ]
+  }
+]}`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func listPoliciesError(req *http.Request) (*http.Response, error) {
+	return nil, listPoliciesErrorType
+}
+
+func getPolicySuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "name": "readinstance",
+    "id": "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+    "rules": [
+      "can listmachine and getmachine"
+    ]
+  }
+`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func getPolicyError(req *http.Request) (*http.Response, error) {
+	return nil, getPolicyErrorType
+}
+
+func getPolicyBadeDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "name": "readinstance",
+    "id": "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+    "rules": [
+      "can listmachine and getmachine"
+    ],
+  }`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func getPolicyEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func deletePolicySuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: 204,
+		Header:     header,
+	}, nil
+}
+
+func deletePolicyError(req *http.Request) (*http.Response, error) {
+	return nil, deletePolicyErrorType
+}
+
+func updatePolicySuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+  "name": "Updated Name",
+  "id": "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+  "rules": [
+    "can rebootMachine"
+  ],
+  "description": "Updated Description"
+}
+`)
+
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func updatePolicyError(req *http.Request) (*http.Response, error) {
+	return nil, updatePolicyErrorType
+}
+
+func createPolicySuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+  "name": "Test Policy",
+  "id": "8700e959-4cb3-4337-8afa-fb0a53b5366e",
+  "rules": [
+    "CAN rebootmachine"
+  ],
+  "description": "Test Description"
+}
+`)
+
+	return &http.Response{
+		StatusCode: 201,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func createPolicyError(req *http.Request) (*http.Response, error) {
+	return nil, createPolicyErrorType
+}

--- a/identity/policies_test.go
+++ b/identity/policies_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 var (
-	listPoliciesErrorType = errors.New("Error executing ListPolicies request:")
-	getPolicyErrorType    = errors.New("Error executing GetPolicy request:")
-	deletePolicyErrorType = errors.New("Error executing DeletePolicy request:")
-	updatePolicyErrorType = errors.New("Error executing UpdatePolicy request:")
-	createPolicyErrorType = errors.New("Error executing CreatePolicy request:")
+	fakePolicyId           = "95ca7b25-5c8f-4c1b-92da-4276f23805ds"
+	aDifferentFakePolicyId = "95ca7b25-5c8f-4c1b-92da-4276f23807f3"
+	listPoliciesErrorType  = errors.New("unable to list policies")
+	getPolicyErrorType     = errors.New("unable to get policy")
+	deletePolicyErrorType  = errors.New("unable to delete policy")
+	updatePolicyErrorType  = errors.New("unable to update policy")
+	createPolicyErrorType  = errors.New("unable to create policy")
 )
 
 func TestListPolicies(t *testing.T) {
@@ -31,6 +33,7 @@ func TestListPolicies(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+
 		return policies, nil
 	}
 
@@ -84,7 +87,7 @@ func TestListPolicies(t *testing.T) {
 			t.Error("expected resp to be nil")
 		}
 
-		if !strings.Contains(err.Error(), "Error executing ListPolicies request:") {
+		if !strings.Contains(err.Error(), "unable to list policies") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -97,16 +100,17 @@ func TestGetPolicy(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		user, err := ic.Policies().Get(ctx, &identity.GetPolicyInput{
-			PolicyID: "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+			PolicyID: fakePolicyId,
 		})
 		if err != nil {
 			return nil, err
 		}
+
 		return user, nil
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), getPolicySuccess)
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, fakePolicyId), getPolicySuccess)
 
 		resp, err := do(context.Background(), identityClient)
 		if err != nil {
@@ -119,7 +123,7 @@ func TestGetPolicy(t *testing.T) {
 	})
 
 	t.Run("eof", func(t *testing.T) {
-		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), getPolicyEmpty)
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, fakePolicyId), getPolicyEmpty)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
@@ -132,7 +136,7 @@ func TestGetPolicy(t *testing.T) {
 	})
 
 	t.Run("bad_decode", func(t *testing.T) {
-		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), getPolicyBadeDecode)
+		testutils.RegisterResponder("GET", fmt.Sprintf("/%s/policies/%s", accountUrl, fakePolicyId), getPolicyBadeDecode)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
@@ -155,7 +159,7 @@ func TestGetPolicy(t *testing.T) {
 			t.Error("expected resp to be nil")
 		}
 
-		if !strings.Contains(err.Error(), "Error executing GetPolicy request:") {
+		if !strings.Contains(err.Error(), "unable to get policy") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -168,12 +172,12 @@ func TestDeletePolicy(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		return ic.Policies().Delete(ctx, &identity.DeletePolicyInput{
-			PolicyID: "8700e959-4cb3-4337-8afa-fb0a53b5366e",
+			PolicyID: fakePolicyId,
 		})
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("DELETE", fmt.Sprintf("/%s/policies/%s", accountUrl, "8700e959-4cb3-4337-8afa-fb0a53b5366e"), deletePolicySuccess)
+		testutils.RegisterResponder("DELETE", fmt.Sprintf("/%s/policies/%s", accountUrl, fakePolicyId), deletePolicySuccess)
 
 		err := do(context.Background(), identityClient)
 		if err != nil {
@@ -189,7 +193,7 @@ func TestDeletePolicy(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(err.Error(), "Error executing DeletePolicy request:") {
+		if !strings.Contains(err.Error(), "unable to delete policy") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -202,18 +206,19 @@ func TestUpdatePolicy(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		policy, err := ic.Policies().Update(ctx, &identity.UpdatePolicyInput{
-			PolicyID:    "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
+			PolicyID:    fakePolicyId,
 			Description: "Updated Description",
 			Name:        "Updated Name",
 		})
 		if err != nil {
 			return nil, err
 		}
+
 		return policy, nil
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), updatePolicySuccess)
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies/%s", accountUrl, fakePolicyId), updatePolicySuccess)
 
 		_, err := do(context.Background(), identityClient)
 		if err != nil {
@@ -222,20 +227,20 @@ func TestUpdatePolicy(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies/%s", accountUrl, "95ca7b25-5c8f-4c1b-92da-4276f23807f3"), updatePolicyError)
+		testutils.RegisterResponder("POST", fmt.Sprintf("/%s/policies/%s", accountUrl, aDifferentFakePolicyId), updatePolicyError)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(err.Error(), "Error executing UpdatePolicy request:") {
+		if !strings.Contains(err.Error(), "unable to update policy") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
 }
 
-func TestCreatePolocy(t *testing.T) {
+func TestCreatePolicy(t *testing.T) {
 	identityClient := MockIdentityClient()
 
 	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Policy, error) {
@@ -250,6 +255,7 @@ func TestCreatePolocy(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
+
 		return policy, nil
 	}
 
@@ -270,7 +276,7 @@ func TestCreatePolocy(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(err.Error(), "Error executing CreatePolicy request:") {
+		if !strings.Contains(err.Error(), "unable to create policy") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -279,6 +285,7 @@ func TestCreatePolocy(t *testing.T) {
 func listPoliciesEmpty(req *http.Request) (*http.Response, error) {
 	header := http.Header{}
 	header.Add("Content-Type", "application/json")
+
 	return &http.Response{
 		StatusCode: 200,
 		Header:     header,
@@ -306,6 +313,7 @@ func listPoliciesSuccess(req *http.Request) (*http.Response, error) {
     ]
   }
 ]`)
+
 	return &http.Response{
 		StatusCode: 200,
 		Header:     header,
@@ -326,6 +334,7 @@ func listPoliciesBadeDecode(req *http.Request) (*http.Response, error) {
     ]
   }
 ]}`)
+
 	return &http.Response{
 		StatusCode: 200,
 		Header:     header,
@@ -349,6 +358,7 @@ func getPolicySuccess(req *http.Request) (*http.Response, error) {
     ]
   }
 `)
+
 	return &http.Response{
 		StatusCode: 200,
 		Header:     header,
@@ -371,6 +381,7 @@ func getPolicyBadeDecode(req *http.Request) (*http.Response, error) {
       "can listmachine and getmachine"
     ],
   }`)
+
 	return &http.Response{
 		StatusCode: 200,
 		Header:     header,
@@ -381,6 +392,7 @@ func getPolicyBadeDecode(req *http.Request) (*http.Response, error) {
 func getPolicyEmpty(req *http.Request) (*http.Response, error) {
 	header := http.Header{}
 	header.Add("Content-Type", "application/json")
+
 	return &http.Response{
 		StatusCode: 200,
 		Header:     header,
@@ -433,7 +445,7 @@ func createPolicySuccess(req *http.Request) (*http.Response, error) {
 
 	body := strings.NewReader(`{
   "name": "Test Policy",
-  "id": "8700e959-4cb3-4337-8afa-fb0a53b5366e",
+  "id": "95ca7b25-5c8f-4c1b-92da-4276f23807f3",
   "rules": [
     "CAN rebootmachine"
   ],

--- a/identity/roles.go
+++ b/identity/roles.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/joyent/triton-go/client"
+	"github.com/pkg/errors"
 )
 
 type RolesClient struct {
@@ -36,13 +36,13 @@ func (c *RolesClient) List(ctx context.Context, _ *ListRolesInput) ([]*Role, err
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing ListRoles request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to list roles")
 	}
 
 	var result []*Role
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding ListRoles response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode list roles response")
 	}
 
 	return result, nil
@@ -63,13 +63,13 @@ func (c *RolesClient) Get(ctx context.Context, input *GetRoleInput) (*Role, erro
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing GetRole request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to get role")
 	}
 
 	var result *Role
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding GetRole response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode get roles response")
 	}
 
 	return result, nil
@@ -104,13 +104,14 @@ func (c *RolesClient) Create(ctx context.Context, input *CreateRoleInput) (*Role
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing CreateRole request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to create role")
+
 	}
 
 	var result *Role
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding CreateRole response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode create role response")
 	}
 
 	return result, nil
@@ -148,13 +149,13 @@ func (c *RolesClient) Update(ctx context.Context, input *UpdateRoleInput) (*Role
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing UpdateRole request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to update role")
 	}
 
 	var result *Role
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding UpdateRole response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode update role response")
 	}
 
 	return result, nil
@@ -175,7 +176,7 @@ func (c *RolesClient) Delete(ctx context.Context, input *DeleteRoleInput) error 
 		defer respReader.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing DeleteRole request: {{err}}", err)
+		return errors.Wrap(err, "unable to delete role")
 	}
 
 	return nil

--- a/identity/roles_test.go
+++ b/identity/roles_test.go
@@ -1,0 +1,460 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/joyent/triton-go/identity"
+	"github.com/joyent/triton-go/testutils"
+)
+
+var (
+	fakeRoleId          = "1234562335"
+	listRolesErrorType  = errors.New("unable to list roles")
+	getRoleErrorType    = errors.New("unable to get role")
+	deleteRoleErrorType = errors.New("unable to delete role")
+	createRoleErrorType = errors.New("unable to create role")
+	updateRoleErrorType = errors.New("unable to update role")
+)
+
+func TestDeleteRole(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) error {
+		defer testutils.DeactivateClient()
+
+		return ic.Roles().Delete(ctx, &identity.DeleteRoleInput{
+			RoleID: fakeRoleId,
+		})
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("DELETE", path.Join("/", accountUrl, "roles", fakeRoleId), deleteRoleSuccess)
+
+		err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("DELETE", path.Join("/", accountUrl, "roles"), deleteRoleError)
+
+		err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to delete role") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestCreateRole(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Role, error) {
+		defer testutils.DeactivateClient()
+
+		role, err := ic.Roles().Create(ctx, &identity.CreateRoleInput{
+			Name: "readable",
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		return role, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("POST", path.Join("/", accountUrl, "roles"), createRoleSuccess)
+
+		_, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("POST", path.Join("/", accountUrl, "roles"), createRoleError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to create role") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestUpdateRole(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Role, error) {
+		defer testutils.DeactivateClient()
+
+		user, err := ic.Roles().Update(ctx, &identity.UpdateRoleInput{
+			RoleID: "e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+			Name:   "updated-role-name",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return user, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("POST", path.Join("/", accountUrl, "roles", "e53b8fec-e661-4ded-a21e-959c9ba08cb2"), updateRoleSuccess)
+
+		_, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("POST", path.Join("/", accountUrl, "roles", "e53b8fec-e661-4ded-a21e-959c9ba08cb2"), updateRoleError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to update role") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestListRoles(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) ([]*identity.Role, error) {
+		defer testutils.DeactivateClient()
+
+		roles, err := ic.Roles().List(ctx, &identity.ListRolesInput{})
+		if err != nil {
+			return nil, err
+		}
+		return roles, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles"), listRolesSuccess)
+
+		resp, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles"), listRolesEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles"), listRolesBadeDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles"), listRolesError)
+
+		resp, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Error("expected resp to be nil")
+		}
+
+		if !strings.Contains(err.Error(), "unable to list roles") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestGetRole(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.Role, error) {
+		defer testutils.DeactivateClient()
+
+		role, err := ic.Roles().Get(ctx, &identity.GetRoleInput{
+			RoleID: fakeRoleId,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return role, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleSuccess)
+
+		resp, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF: found %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleBadeDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail: found %s", err)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles"), getRoleError)
+
+		resp, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+		if resp != nil {
+			t.Error("expected resp to be nil")
+		}
+
+		if !strings.Contains(err.Error(), "unable to get role") {
+			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func deleteRoleSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: 204,
+		Header:     header,
+	}, nil
+}
+
+func deleteRoleError(req *http.Request) (*http.Response, error) {
+	return nil, deleteRoleErrorType
+}
+
+func createRoleSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+  "name": "readable",
+  "id": "e53b8fec-e661-4ded-a21e-959c9ba08cb2"
+}
+`)
+
+	return &http.Response{
+		StatusCode: 201,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func createRoleError(req *http.Request) (*http.Response, error) {
+	return nil, createRoleErrorType
+}
+
+func updateRoleSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+  "name": "updated-role-name",
+  "id": "e53b8fec-e661-4ded-a21e-959c9ba08cb2"
+}
+`)
+
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func updateRoleError(req *http.Request) (*http.Response, error) {
+	return nil, updateRoleErrorType
+}
+
+func listRolesEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func listRolesSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`[
+	{
+    "name": "readable",
+    "id": "e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+    "members": [
+      "foo"
+    ],
+    "default_members": [
+      "foo"
+    ],
+    "policies": [
+      "readinstance"
+    ]
+  }
+]`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func listRolesBadeDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{[
+	{
+    "name": "readable",
+    "id": "e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+    "members": [
+      "foo"
+    ],
+    "default_members": [
+      "foo"
+    ],
+    "policies": [
+      "readinstance"
+    ]
+  }
+]}`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func listRolesError(req *http.Request) (*http.Response, error) {
+	return nil, listRolesErrorType
+}
+
+func getRoleSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "name": "readable",
+    "id": "e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+    "members": [
+      "foo"
+    ],
+    "default_members": [
+      "foo"
+    ],
+    "policies": [
+      "readinstance"
+    ]
+  }
+`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func getRoleError(req *http.Request) (*http.Response, error) {
+	return nil, getRoleErrorType
+}
+
+func getRoleBadeDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+    "name": "readable",
+    "id": "e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+    "members": [
+      "foo"
+    ],
+    "default_members": [
+      "foo"
+    ],
+    "policies": [
+      "readinstance"
+    ],
+  }`)
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func getRoleEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	return &http.Response{
+		StatusCode: 200,
+		Header:     header,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}, nil
+}

--- a/identity/users.go
+++ b/identity/users.go
@@ -7,8 +7,8 @@ import (
 	"path"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/joyent/triton-go/client"
+	"github.com/pkg/errors"
 )
 
 type UsersClient struct {
@@ -47,13 +47,13 @@ func (c *UsersClient) List(ctx context.Context, _ *ListUsersInput) ([]*User, err
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing List request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to list users")
 	}
 
 	var result []*User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding List response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode list users response")
 	}
 
 	return result, nil
@@ -74,13 +74,13 @@ func (c *UsersClient) Get(ctx context.Context, input *GetUserInput) (*User, erro
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing Get request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to get user")
 	}
 
 	var result *User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding Get response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode get user response")
 	}
 
 	return result, nil
@@ -101,7 +101,7 @@ func (c *UsersClient) Delete(ctx context.Context, input *DeleteUserInput) error 
 		defer respReader.Close()
 	}
 	if err != nil {
-		return errwrap.Wrapf("Error executing Delete request: {{err}}", err)
+		return errors.Wrap(err, "unable to delete user")
 	}
 
 	return nil
@@ -134,13 +134,13 @@ func (c *UsersClient) Create(ctx context.Context, input *CreateUserInput) (*User
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing Create request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to create user")
 	}
 
 	var result *User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding Create response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode create user response")
 	}
 
 	return result, nil
@@ -173,13 +173,13 @@ func (c *UsersClient) Update(ctx context.Context, input *UpdateUserInput) (*User
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing Update request: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to update user")
 	}
 
 	var result *User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errwrap.Wrapf("Error decoding Update response: {{err}}", err)
+		return nil, errors.Wrap(err, "unable to decode update user response")
 	}
 
 	return result, nil

--- a/identity/users_test.go
+++ b/identity/users_test.go
@@ -16,11 +16,11 @@ import (
 const accountUrl = "testing"
 
 var (
-	listUserErrorType   = errors.New("Error executing List request:")
-	getUserErrorType    = errors.New("Error executing Get request:")
-	deleteUserErrorType = errors.New("Error executing Delete request:")
-	createUserErrorType = errors.New("Error executing Create request:")
-	updateUserErrorType = errors.New("Error executing Update request:")
+	listUserErrorType   = errors.New("unable to list users")
+	getUserErrorType    = errors.New("unable to get user")
+	deleteUserErrorType = errors.New("unable to delete user")
+	createUserErrorType = errors.New("unable to create user")
+	updateUserErrorType = errors.New("unable to update user")
 )
 
 func MockIdentityClient() *identity.IdentityClient {
@@ -94,7 +94,7 @@ func TestListUsers(t *testing.T) {
 			t.Error("expected resp to be nil")
 		}
 
-		if !strings.Contains(err.Error(), "Error executing List request:") {
+		if !strings.Contains(err.Error(), "unable to list users") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -165,7 +165,7 @@ func TestGetUser(t *testing.T) {
 			t.Error("expected resp to be nil")
 		}
 
-		if !strings.Contains(err.Error(), "Error executing Get request:") {
+		if !strings.Contains(err.Error(), "unable to get user") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -199,7 +199,7 @@ func TestDeleteUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(err.Error(), "Error executing Delete request:") {
+		if !strings.Contains(err.Error(), "unable to delete user") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -240,7 +240,7 @@ func TestCreateUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(err.Error(), "Error executing Create request:") {
+		if !strings.Contains(err.Error(), "unable to create user") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})
@@ -279,7 +279,7 @@ func TestUpdateUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(err.Error(), "Error executing Update request:") {
+		if !strings.Contains(err.Error(), "unable to update user") {
 			t.Errorf("expected error to equal testError: found %s", err)
 		}
 	})


### PR DESCRIPTION
```
% [add-support-for-policies] % go test -v
=== RUN   TestListPolicies
=== RUN   TestListPolicies/successful
=== RUN   TestListPolicies/eof
=== RUN   TestListPolicies/bad_decode
=== RUN   TestListPolicies/error
--- PASS: TestListPolicies (0.00s)
    --- PASS: TestListPolicies/successful (0.00s)
    --- PASS: TestListPolicies/eof (0.00s)
    --- PASS: TestListPolicies/bad_decode (0.00s)
    --- PASS: TestListPolicies/error (0.00s)
=== RUN   TestGetPolicy
=== RUN   TestGetPolicy/successful
=== RUN   TestGetPolicy/eof
=== RUN   TestGetPolicy/bad_decode
=== RUN   TestGetPolicy/error
--- PASS: TestGetPolicy (0.00s)
    --- PASS: TestGetPolicy/successful (0.00s)
    --- PASS: TestGetPolicy/eof (0.00s)
    --- PASS: TestGetPolicy/bad_decode (0.00s)
    --- PASS: TestGetPolicy/error (0.00s)
=== RUN   TestDeletePolicy
=== RUN   TestDeletePolicy/successful
=== RUN   TestDeletePolicy/error
--- PASS: TestDeletePolicy (0.00s)
    --- PASS: TestDeletePolicy/successful (0.00s)
    --- PASS: TestDeletePolicy/error (0.00s)
=== RUN   TestUpdatePolicy
=== RUN   TestUpdatePolicy/successful
=== RUN   TestUpdatePolicy/error
--- PASS: TestUpdatePolicy (0.00s)
    --- PASS: TestUpdatePolicy/successful (0.00s)
    --- PASS: TestUpdatePolicy/error (0.00s)
=== RUN   TestCreatePolocy
=== RUN   TestCreatePolocy/successful
=== RUN   TestCreatePolocy/error
--- PASS: TestCreatePolocy (0.00s)
    --- PASS: TestCreatePolocy/successful (0.00s)
    --- PASS: TestCreatePolocy/error (0.00s)
=== RUN   TestListUsers
=== RUN   TestListUsers/successful
=== RUN   TestListUsers/eof
=== RUN   TestListUsers/bad_decode
=== RUN   TestListUsers/error
--- PASS: TestListUsers (0.00s)
    --- PASS: TestListUsers/successful (0.00s)
    --- PASS: TestListUsers/eof (0.00s)
    --- PASS: TestListUsers/bad_decode (0.00s)
    --- PASS: TestListUsers/error (0.00s)
=== RUN   TestGetUser
=== RUN   TestGetUser/successful
=== RUN   TestGetUser/eof
=== RUN   TestGetUser/bad_decode
=== RUN   TestGetUser/error
--- PASS: TestGetUser (0.00s)
    --- PASS: TestGetUser/successful (0.00s)
    --- PASS: TestGetUser/eof (0.00s)
    --- PASS: TestGetUser/bad_decode (0.00s)
    --- PASS: TestGetUser/error (0.00s)
=== RUN   TestDeleteUser
=== RUN   TestDeleteUser/successful
=== RUN   TestDeleteUser/error
--- PASS: TestDeleteUser (0.00s)
    --- PASS: TestDeleteUser/successful (0.00s)
    --- PASS: TestDeleteUser/error (0.00s)
=== RUN   TestCreateUser
=== RUN   TestCreateUser/successful
=== RUN   TestCreateUser/error
--- PASS: TestCreateUser (0.00s)
    --- PASS: TestCreateUser/successful (0.00s)
    --- PASS: TestCreateUser/error (0.00s)
=== RUN   TestUpdateUser
=== RUN   TestUpdateUser/successful
=== RUN   TestUpdateUser/error
--- PASS: TestUpdateUser (0.00s)
    --- PASS: TestUpdateUser/successful (0.00s)
    --- PASS: TestUpdateUser/error (0.00s)
PASS
ok  	github.com/joyent/triton-go/identity	0.012s
```