### PR TITLE
Adding Code Coverage to GNUMakefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pkg/
 *.test
 *.iml
 Notes.md
+coverage.txt

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,9 +12,8 @@ tools:: ## Download and install all dev/code tools
 	go test -i $(TEST) || exit 1
 
 test:: ## Run unit tests
-	@echo "==> Running unit tests"
-	@echo $(TEST) | \
-		xargs -t go test -v $(TESTARGS) -timeout=30s -parallel=1 | grep -Ev 'TRITON_TEST|TestAcc'
+	@echo "==> Running unit test with coverage"
+	@./scripts/go-test-with-coverage.sh
 
 testacc:: ## Run acceptance tests
 	@echo "==> Running acceptance tests"

--- a/scripts/go-test-with-coverage.sh
+++ b/scripts/go-test-with-coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor | grep -v examples | grep -v testutils); do
+    go test -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
Gives an output as follows:

```
==> Running unit test with coverage
?       github.com/joyent/triton-go    [no test files]
ok      github.com/joyent/triton-go/account    0.015s    coverage: 90.9% of statements
?       github.com/joyent/triton-go/authentication    [no test files]
ok      github.com/joyent/triton-go/client    0.012s    coverage: 13.2% of statements
ok      github.com/joyent/triton-go/compute    0.014s    coverage: 9.9% of statements
ok      github.com/joyent/triton-go/identity    0.014s    coverage: 92.0% of statements
ok      github.com/joyent/triton-go/network    0.015s    coverage: 94.5% of statements
ok      github.com/joyent/triton-go/storage    0.013s    coverage: 3.8% of statements
```