### PR TITLE
Refactor current comments to make them mode idiomatic.

### DIFF
--- a/version.go
+++ b/version.go
@@ -13,20 +13,30 @@ import (
 	"runtime"
 )
 
-// The main version number of the current released Triton-go SDK.
+// Version represents main version number of the current release
+// of the Triton-go SDK.
 const Version = "1.0.0"
 
-// A pre-release marker for the version. If this is "" (empty string)
-// then it means that it is a final release. Otherwise, this is a pre-release
-// such as "dev" (in development), "beta", "rc1", etc.
+// Prerelease adds a pre-release marker to the version.
+//
+// If this is "" (empty string) then it means that it is a final release.
+// Otherwise, this is a pre-release such as "dev" (in development), "beta",
+// "rc1", etc.
 var Prerelease = "dev"
 
+// UserAgent returns a Triton-go characteristic string that allows the
+// network protocol peers to identify the version, release and runtime
+// of the Triton-go client from which the requests originate.
 func UserAgent() string {
 	if Prerelease != "" {
-		return fmt.Sprintf("triton-go/%s-%s (%s-%s; %s)", Version, Prerelease, runtime.GOARCH, runtime.GOOS, runtime.Version())
-	} else {
-		return fmt.Sprintf("triton-go/%s (%s-%s; %s)", Version, runtime.GOARCH, runtime.GOOS, runtime.Version())
+		return fmt.Sprintf("triton-go/%s-%s (%s-%s; %s)", Version, Prerelease,
+			runtime.GOARCH, runtime.GOOS, runtime.Version())
 	}
+
+	return fmt.Sprintf("triton-go/%s (%s-%s; %s)", Version, runtime.GOARCH,
+		runtime.GOOS, runtime.Version())
 }
 
+// CloudAPIMajorVersion specifies the CloudAPI version compatibility
+// for current release of the Triton-go SDK.
 const CloudAPIMajorVersion = "8"


### PR DESCRIPTION
This commit changes comments for some of the exported variables and functions to
make them more idiomatic, and also adds comments where such were missing.

Also, remove the else statement from the `UserAgent()` function which is not
needed given that this function returns values immediately without doing
anything else.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>