### PR TITLE
Add missing error handling.

### DIFF
--- a/compute/instances_test.go
+++ b/compute/instances_test.go
@@ -109,6 +109,10 @@ func TestAccInstances_Create(t *testing.T) {
 						Name:    "ubuntu-16.04",
 						Version: "20170403",
 					})
+					if err != nil {
+						return nil, err
+					}
+
 					img := images[0]
 
 					var net *network.Network

--- a/examples/compute/volumes/crud/main.go
+++ b/examples/compute/volumes/crud/main.go
@@ -133,12 +133,15 @@ func main() {
 		ID:   volume.ID,
 	})
 	if err != nil {
-		log.Fatalf("compute.Volumes.Update: %v", err)
+		log.Fatalf("Failed to update name of volume %q: %v", volume.ID, err)
 	}
 
 	volume, err = c.Volumes().Get(context.Background(), &compute.GetVolumeInput{
 		ID: volume.ID,
 	})
+	if err != nil {
+		log.Fatalf("Failed to retrieve details of volume %q: %v", volume.ID, err)
+	}
 
 	fmt.Println("Name:", volume.Name)
 	fmt.Println("State:", volume.State)
@@ -148,6 +151,6 @@ func main() {
 		ID: volume.ID,
 	})
 	if err != nil {
-		log.Fatalf("Delete(): %v", err)
+		log.Fatalf("Failed to delete volume %q: %v", volume.ID, err)
 	}
 }

--- a/examples/network/create_fabric.go
+++ b/examples/network/create_fabric.go
@@ -120,6 +120,9 @@ func main() {
 		Enabled: false,
 		Rule:    "FROM any TO tag \"bone-thug\" = \"basket-ball\" ALLOW udp PORT 8600",
 	})
+	if err != nil {
+		log.Fatalf("Failed to create Firewall Rule: %v", err)
+	}
 
 	fmt.Println("Firewall Rule was successfully added!")
 	time.Sleep(5 * time.Second)
@@ -127,6 +130,9 @@ func main() {
 	err = n.Firewall().DeleteRule(context.Background(), &network.DeleteRuleInput{
 		ID: fwrule.ID,
 	})
+	if err != nil {
+		log.Fatalf("Failed to delete Firewall Rule: %v", err)
+	}
 
 	fmt.Println("Firewall Rule was successfully deleted!")
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
This commit adds error handling at places where the `err` variable was assigned
after an API call was made, but it was never used to check for possible errors.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>