### PR TITLE
Add support for the ChangeUserPassword call available in the CloudAPI.

### DIFF
--- a/identity/users.go
+++ b/identity/users.go
@@ -16,7 +16,8 @@ import (
 	"time"
 
 	"github.com/joyent/triton-go/client"
-	"github.com/pkg/errors"
+	"github.com/joyent/triton-go/errors"
+	pkgerrors "github.com/pkg/errors"
 )
 
 type UsersClient struct {
@@ -55,13 +56,13 @@ func (c *UsersClient) List(ctx context.Context, _ *ListUsersInput) ([]*User, err
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to list users")
+		return nil, pkgerrors.Wrap(err, "unable to list users")
 	}
 
 	var result []*User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errors.Wrap(err, "unable to decode list users response")
+		return nil, pkgerrors.Wrap(err, "unable to decode list users response")
 	}
 
 	return result, nil
@@ -82,13 +83,13 @@ func (c *UsersClient) Get(ctx context.Context, input *GetUserInput) (*User, erro
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get user")
+		return nil, pkgerrors.Wrap(err, "unable to get user")
 	}
 
 	var result *User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errors.Wrap(err, "unable to decode get user response")
+		return nil, pkgerrors.Wrap(err, "unable to decode get user response")
 	}
 
 	return result, nil
@@ -109,7 +110,7 @@ func (c *UsersClient) Delete(ctx context.Context, input *DeleteUserInput) error 
 		defer respReader.Close()
 	}
 	if err != nil {
-		return errors.Wrap(err, "unable to delete user")
+		return pkgerrors.Wrap(err, "unable to delete user")
 	}
 
 	return nil
@@ -142,13 +143,13 @@ func (c *UsersClient) Create(ctx context.Context, input *CreateUserInput) (*User
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create user")
+		return nil, pkgerrors.Wrap(err, "unable to create user")
 	}
 
 	var result *User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errors.Wrap(err, "unable to decode create user response")
+		return nil, pkgerrors.Wrap(err, "unable to decode create user response")
 	}
 
 	return result, nil
@@ -181,13 +182,69 @@ func (c *UsersClient) Update(ctx context.Context, input *UpdateUserInput) (*User
 		defer respReader.Close()
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to update user")
+		return nil, pkgerrors.Wrap(err, "unable to update user")
 	}
 
 	var result *User
 	decoder := json.NewDecoder(respReader)
 	if err = decoder.Decode(&result); err != nil {
-		return nil, errors.Wrap(err, "unable to decode update user response")
+		return nil, pkgerrors.Wrap(err, "unable to decode update user response")
+	}
+
+	return result, nil
+}
+
+// ChangeUserPasswordInput represents the options that can be specified
+// when changing an existing user password.
+type ChangeUserPasswordInput struct {
+	// The unique ID of the user for which to change the password. Required.
+	UserID string
+	// User password. Required.
+	Password string `json:"password"`
+	// User password confirmation. Required.
+	PasswordConfirmation string `json:"password_confirmation"`
+}
+
+// ChangeUserPassword updates password for an existing user. Returns updated
+// user object, or an error otherwise.
+func (c *UsersClient) ChangeUserPassword(ctx context.Context, input *ChangeUserPasswordInput) (*User, error) {
+	fullPath := path.Join("/", c.Client.AccountName, "users", input.UserID, "change_password")
+
+	// Verify both values locally, and save on an unnecessary API call,
+	// but should the values be different, then return the same error
+	// as what the CloudAPI would.
+	if input.Password != input.PasswordConfirmation {
+		return nil, pkgerrors.New("password and password confirmation must have the same value")
+	}
+
+	reqInputs := client.RequestInput{
+		Method: http.MethodPost,
+		Path:   fullPath,
+		Body:   input,
+	}
+	respReader, err := c.Client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		// The `passwordInHistory` error message originates directly
+		// from Triton's UFDS service through the CloudAPI, but it's
+		// not very informative to the user.
+		apiError, ok := pkgerrors.Cause(err).(*errors.APIError)
+		if ok && apiError.Message == "passwordInHistory" {
+			err = &errors.APIError{
+				StatusCode: apiError.StatusCode,
+				Code:       apiError.Code,
+				Message:    "previous password cannot be reused",
+			}
+		}
+		return nil, pkgerrors.Wrap(err, "unable to change user password")
+	}
+
+	var result *User
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to decode change user password response")
 	}
 
 	return result, nil


### PR DESCRIPTION
This commit adds support for the ChangeUserPassword call available in the
CloudAPI, which allows for password to be updated for any valid Trition user.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>