### PR TITLE
Add support for the SetRoleTags call available in the CloudAPI.

### DIFF
--- a/identity/roles_test.go
+++ b/identity/roles_test.go
@@ -11,25 +11,278 @@ package identity_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"path"
 	"strings"
 	"testing"
+	"time"
 
+	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/identity"
 	"github.com/joyent/triton-go/testutils"
 )
 
+const fakeRoleID = "e53b8fec-e661-4ded-a21e-959c9ba08cb2"
+
 var (
-	fakeRoleId          = "1234562335"
-	listRolesErrorType  = errors.New("unable to list roles")
-	getRoleErrorType    = errors.New("unable to get role")
-	deleteRoleErrorType = errors.New("unable to delete role")
-	createRoleErrorType = errors.New("unable to create role")
-	updateRoleErrorType = errors.New("unable to update role")
+	listRolesErrorType   = errors.New("unable to list roles")
+	getRoleErrorType     = errors.New("unable to get role")
+	deleteRoleErrorType  = errors.New("unable to delete role")
+	createRoleErrorType  = errors.New("unable to create role")
+	updateRoleErrorType  = errors.New("unable to update role")
+	setRoleTagsErrorType = errors.New("unable to set role tags")
+	getRoleTagsErrorType = errors.New("unable to get role tags")
 )
 
+func TestAccIdentity_SetRoleTags(t *testing.T) {
+	testRoleName := testutils.RandPrefixString("TestAccSetRoleTags", 32)
+
+	// Holds newly created role.
+	var newRole *identity.Role
+
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepClient{
+				StateBagKey: "identity",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return identity.NewClient(config)
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "identity",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.CreateRoleInput{
+						Name: testRoleName,
+					}
+					role, err := c.Roles().Create(ctx, input)
+					newRole = role
+
+					// Allow a few seconds for the new role
+					// to propagate within CloudAPI.
+					time.Sleep(5 * time.Second)
+
+					return role, err
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					role, roleOk := callState.(*identity.Role)
+					if !roleOk {
+						log.Println("Expected state to include role1")
+						return
+					}
+
+					if role.Name != testRoleName {
+						log.Printf("Expected role name to be %q, got %q\n",
+							testRoleName, role.Name)
+						return
+					}
+
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.DeleteRoleInput{
+						RoleID: role.ID,
+					}
+					err := c.Roles().Delete(ctx, input)
+					if err != nil {
+						log.Printf("Could not delete role %q: %v\n", role.ID, err)
+					}
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "setRoleTags",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.SetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   newRole.ID,
+						RoleTags: []string{
+							newRole.Name,
+						},
+					}
+					return c.Roles().SetRoleTags(ctx, input)
+				},
+			},
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					roleTagsRaw, found := state.GetOk("setRoleTags")
+					if !found {
+						return fmt.Errorf("State key %q not found", "setRoleTags")
+					}
+
+					roleTags, roleTagsOk := roleTagsRaw.(*identity.RoleTags)
+					if !roleTagsOk {
+						return errors.New("Expected state to include role tags")
+					}
+
+					actual := roleTags.RoleTags[0]
+
+					if actual != testRoleName {
+						return fmt.Errorf("Expected role tags to contain %q, got %q",
+							testRoleName, actual)
+					}
+
+					return nil
+
+				},
+			},
+			&testutils.StepAPICall{
+				ErrorKey: "setRoleTagsError",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.GetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   "Bad-Role-Resource-ID",
+					}
+					return c.Roles().GetRoleTags(ctx, input)
+				},
+			},
+			&testutils.StepAssertTritonError{
+				ErrorKey: "setRoleTagsError",
+				Code:     "ResourceNotFound",
+			},
+		},
+	})
+}
+
+func TestAccIdentity_GetRoleTags(t *testing.T) {
+	testRoleName := testutils.RandPrefixString("TestAccGetRoleTags", 32)
+
+	// Holds newly created role.
+	var newRole *identity.Role
+
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepClient{
+				StateBagKey: "identity",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return identity.NewClient(config)
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "identity",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.CreateRoleInput{
+						Name: testRoleName,
+					}
+					role, err := c.Roles().Create(ctx, input)
+					newRole = role
+
+					// Allow a few seconds for the new role
+					// to propagate within CloudAPI.
+					time.Sleep(5 * time.Second)
+
+					return role, err
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					role, roleOk := callState.(*identity.Role)
+					if !roleOk {
+						log.Println("Expected state to include role1")
+						return
+					}
+
+					if role.Name != testRoleName {
+						log.Printf("Expected role name to be %q, got %q\n",
+							testRoleName, role.Name)
+						return
+					}
+
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.DeleteRoleInput{
+						RoleID: role.ID,
+					}
+					err := c.Roles().Delete(ctx, input)
+					if err != nil {
+						log.Printf("Could not delete role %q: %v\n", role.ID, err)
+					}
+				},
+			},
+			&testutils.StepAPICall{
+				StateBagKey: "getRoleTags",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					setInput := &identity.SetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   newRole.ID,
+						RoleTags: []string{
+							newRole.Name,
+						},
+					}
+					_, err := c.Roles().SetRoleTags(ctx, setInput)
+					if err != nil {
+						return nil, err
+					}
+
+					// Allow a few seconds for the new role tag
+					// to propagate within CloudAPI.
+					time.Sleep(5 * time.Second)
+
+					getInput := &identity.GetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   newRole.ID,
+					}
+					return c.Roles().GetRoleTags(ctx, getInput)
+				},
+			},
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					roleTagsRaw, found := state.GetOk("getRoleTags")
+					if !found {
+						return fmt.Errorf("State key %q not found", "getRoleTags")
+					}
+
+					roleTags, roleTagsOk := roleTagsRaw.(*identity.RoleTags)
+					if !roleTagsOk {
+						return errors.New("Expected state to include role tags")
+					}
+
+					actual := roleTags.RoleTags[0]
+
+					if actual != testRoleName {
+						return fmt.Errorf("Expected role tags to contain %q, got %q",
+							testRoleName, actual)
+					}
+
+					return nil
+
+				},
+			},
+			&testutils.StepAPICall{
+				ErrorKey: "getRoleTagsError",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*identity.IdentityClient)
+					ctx := context.Background()
+
+					input := &identity.GetRoleTagsInput{
+						ResourceType: "roles",
+						ResourceID:   "Bad-Role-Resource-ID",
+					}
+					return c.Roles().GetRoleTags(ctx, input)
+				},
+			},
+			&testutils.StepAssertTritonError{
+				ErrorKey: "getRoleTagsError",
+				Code:     "ResourceNotFound",
+			},
+		},
+	})
+}
 func TestDeleteRole(t *testing.T) {
 	identityClient := MockIdentityClient()
 
@@ -37,12 +290,12 @@ func TestDeleteRole(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		return ic.Roles().Delete(ctx, &identity.DeleteRoleInput{
-			RoleID: fakeRoleId,
+			RoleID: fakeRoleID,
 		})
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("DELETE", path.Join("/", accountUrl, "roles", fakeRoleId), deleteRoleSuccess)
+		testutils.RegisterResponder("DELETE", path.Join("/", accountUrl, "roles", fakeRoleID), deleteRoleSuccess)
 
 		err := do(context.Background(), identityClient)
 		if err != nil {
@@ -218,7 +471,7 @@ func TestGetRole(t *testing.T) {
 		defer testutils.DeactivateClient()
 
 		role, err := ic.Roles().Get(ctx, &identity.GetRoleInput{
-			RoleID: fakeRoleId,
+			RoleID: fakeRoleID,
 		})
 		if err != nil {
 			return nil, err
@@ -227,7 +480,7 @@ func TestGetRole(t *testing.T) {
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleSuccess)
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleSuccess)
 
 		resp, err := do(context.Background(), identityClient)
 		if err != nil {
@@ -240,7 +493,7 @@ func TestGetRole(t *testing.T) {
 	})
 
 	t.Run("eof", func(t *testing.T) {
-		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleEmpty)
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleEmpty)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
@@ -253,7 +506,7 @@ func TestGetRole(t *testing.T) {
 	})
 
 	t.Run("bad_decode", func(t *testing.T) {
-		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleId), getRoleBadeDecode)
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleBadeDecode)
 
 		_, err := do(context.Background(), identityClient)
 		if err == nil {
@@ -278,6 +531,128 @@ func TestGetRole(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "unable to get role") {
 			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestSetRoleTags(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.RoleTags, error) {
+		defer testutils.DeactivateClient()
+
+		roleTags, err := ic.Roles().SetRoleTags(ctx, &identity.SetRoleTagsInput{
+			ResourceType: "roles",
+			ResourceID:   fakeRoleID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return roleTags, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsSuccess)
+
+		response, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if response == nil {
+			t.Error("expected response to be set, got nil")
+		}
+
+		actual := response.RoleTags[0]
+
+		if actual != "test-role" {
+			t.Errorf("expected role tags to contain test role, got %s", actual)
+		}
+
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to set role tags") {
+			t.Errorf("expected error to equal test error, got %s", err)
+		}
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsEmpty)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "EOF") {
+			t.Errorf("expected error to contain EOF, got %s", err)
+		}
+	})
+
+	t.Run("bad_decode", func(t *testing.T) {
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "roles", fakeRoleID), setRoleTagsBadDecode)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("expected decode to fail, got %s", err)
+		}
+	})
+}
+
+func TestGetRoleTags(t *testing.T) {
+	identityClient := MockIdentityClient()
+
+	do := func(ctx context.Context, ic *identity.IdentityClient) (*identity.RoleTags, error) {
+		defer testutils.DeactivateClient()
+
+		roleTags, err := ic.Roles().GetRoleTags(ctx, &identity.GetRoleTagsInput{
+			ResourceType: "roles",
+			ResourceID:   fakeRoleID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return roleTags, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleTagsSuccess)
+
+		response, err := do(context.Background(), identityClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		actual := response.RoleTags[0]
+
+		if actual != "test-role" {
+			t.Errorf("expected role tags to contain test role, got %s", actual)
+		}
+
+	})
+
+	t.Run("error", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountUrl, "roles", fakeRoleID), getRoleTagsError)
+
+		_, err := do(context.Background(), identityClient)
+		if err == nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(err.Error(), "unable to get role tags") {
+			t.Errorf("expected error to equal test error, got %s", err)
 		}
 	})
 }
@@ -465,4 +840,75 @@ func getRoleEmpty(req *http.Request) (*http.Response, error) {
 		Header:     header,
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 	}, nil
+}
+
+func setRoleTagsSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`
+{
+  "name": "/testing/role/e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+  "role-tag": [
+    "test-role"
+  ]
+}
+`)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func setRoleTagsError(req *http.Request) (*http.Response, error) {
+	return nil, setRoleTagsErrorType
+}
+
+func setRoleTagsBadDecode(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`
+{
+  "name": "/testing/role/e53b8fec-e661-4ded-a21e-959c9ba08cb2",
+  "role-tag": [
+    "test-role",
+  ]
+}
+`)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
+}
+
+func setRoleTagsEmpty(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func getRoleTagsSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+	header.Add("Role-Tag", "test-role")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func getRoleTagsError(req *http.Request) (*http.Response, error) {
+	return nil, getRoleTagsErrorType
 }


### PR DESCRIPTION
This commit adds support for the SetRoleTags call available in the
CloudAPI, which allows for setting a single or multiple role tags
to use with the RBAC, either for an individual resource or for the
whole group of resources (e.g., all the current instances, etc.).

Additionally, this commit also adds GetRoleTags function, whilst not
provided by the CloudAPI, can be used to retrieve a list of currently
set role tags.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>