### PR TITLE
Override HTTP headers prior to backend API call

### DIFF
--- a/account/client.go
+++ b/account/client.go
@@ -9,6 +9,8 @@
 package account
 
 import (
+	"net/http"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/client"
 )
@@ -32,6 +34,12 @@ func NewClient(config *triton.ClientConfig) (*AccountClient, error) {
 		return nil, err
 	}
 	return newAccountClient(client), nil
+}
+
+// SetHeaders allows a consumer of the current client to set custom headers for
+// the next backend HTTP request sent to CloudAPI
+func (c *AccountClient) SetHeader(header *http.Header) {
+	c.Client.RequestHeader = header
 }
 
 // Config returns a c used for accessing functions pertaining

--- a/client/client.go
+++ b/client/client.go
@@ -40,12 +40,13 @@ var (
 
 // Client represents a connection to the Triton Compute or Object Storage APIs.
 type Client struct {
-	HTTPClient  *http.Client
-	Authorizers []authentication.Signer
-	TritonURL   url.URL
-	MantaURL    url.URL
-	AccountName string
-	Username    string
+	HTTPClient    *http.Client
+	RequestHeader *http.Header
+	Authorizers   []authentication.Signer
+	TritonURL     url.URL
+	MantaURL      url.URL
+	AccountName   string
+	Username      string
 }
 
 // New is used to construct a Client in order to make API
@@ -153,6 +154,8 @@ func (c *Client) InsecureSkipTLSVerify() {
 	c.HTTPClient.Transport = httpTransport(true)
 }
 
+// httpTransport is responsible for setting up our HTTP client's transport
+// settings
 func httpTransport(insecureSkipTLSVerify bool) *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -173,6 +176,7 @@ func doNotFollowRedirects(*http.Request, []*http.Request) error {
 	return http.ErrUseLastResponse
 }
 
+// DecodeError decodes a backend Triton error into a more usable Go error type
 func (c *Client) DecodeError(resp *http.Response, requestMethod string) error {
 	err := &errors.APIError{
 		StatusCode: resp.StatusCode,
@@ -192,6 +196,23 @@ func (c *Client) DecodeError(resp *http.Response, requestMethod string) error {
 	return err
 }
 
+// overrideHeader overrides the header of the passed in HTTP request
+func (c *Client) overrideHeader(req *http.Request) {
+	if c.RequestHeader != nil {
+		for k, vs := range *c.RequestHeader {
+			for _, v := range vs {
+				req.Header.Add(k, v)
+			}
+		}
+	}
+}
+
+// resetHeader will reset the struct field that stores custom header
+// information
+func (c *Client) resetHeader() {
+	c.RequestHeader = nil
+}
+
 // -----------------------------------------------------------------------------
 
 type RequestInput struct {
@@ -203,6 +224,8 @@ type RequestInput struct {
 }
 
 func (c *Client) ExecuteRequestURIParams(ctx context.Context, inputs RequestInput) (io.ReadCloser, error) {
+	defer c.resetHeader()
+
 	method := inputs.Method
 	path := inputs.Path
 	body := inputs.Body
@@ -246,6 +269,8 @@ func (c *Client) ExecuteRequestURIParams(ctx context.Context, inputs RequestInpu
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	c.overrideHeader(req)
+
 	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "unable to execute HTTP request")
@@ -265,6 +290,8 @@ func (c *Client) ExecuteRequest(ctx context.Context, inputs RequestInput) (io.Re
 }
 
 func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*http.Response, error) {
+	defer c.resetHeader()
+
 	method := inputs.Method
 	path := inputs.Path
 	body := inputs.Body
@@ -304,6 +331,8 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	c.overrideHeader(req)
+
 	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "unable to execute HTTP request")
@@ -319,6 +348,8 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 }
 
 func (c *Client) ExecuteRequestStorage(ctx context.Context, inputs RequestInput) (io.ReadCloser, http.Header, error) {
+	defer c.resetHeader()
+
 	method := inputs.Method
 	path := inputs.Path
 	query := inputs.Query
@@ -368,6 +399,8 @@ func (c *Client) ExecuteRequestStorage(ctx context.Context, inputs RequestInput)
 		req.URL.RawQuery = query.Encode()
 	}
 
+	c.overrideHeader(req)
+
 	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, nil, pkgerrors.Wrapf(err, "unable to execute HTTP request")
@@ -391,6 +424,8 @@ type RequestNoEncodeInput struct {
 }
 
 func (c *Client) ExecuteRequestNoEncode(ctx context.Context, inputs RequestNoEncodeInput) (io.ReadCloser, http.Header, error) {
+	defer c.resetHeader()
+
 	method := inputs.Method
 	path := inputs.Path
 	query := inputs.Query
@@ -428,6 +463,8 @@ func (c *Client) ExecuteRequestNoEncode(ctx context.Context, inputs RequestNoEnc
 	if query != nil {
 		req.URL.RawQuery = query.Encode()
 	}
+
+	c.overrideHeader(req)
 
 	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {

--- a/compute/client.go
+++ b/compute/client.go
@@ -9,6 +9,8 @@
 package compute
 
 import (
+	"net/http"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/client"
 )
@@ -32,6 +34,12 @@ func NewClient(config *triton.ClientConfig) (*ComputeClient, error) {
 		return nil, err
 	}
 	return newComputeClient(client), nil
+}
+
+// SetHeaders allows a consumer of the current client to set custom headers for
+// the next backend HTTP request sent to CloudAPI
+func (c *ComputeClient) SetHeader(header *http.Header) {
+	c.Client.RequestHeader = header
 }
 
 // Datacenters returns a Compute client used for accessing functions pertaining

--- a/compute/client_test.go
+++ b/compute/client_test.go
@@ -1,0 +1,84 @@
+package compute_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/joyent/triton-go/compute"
+	"github.com/joyent/triton-go/testutils"
+)
+
+// MockComputeClient is used to mock out compute.ComputeClient for all tests
+// under the triton-go/compute package
+func MockComputeClient() *compute.ComputeClient {
+	return &compute.ComputeClient{
+		Client: testutils.NewMockClient(testutils.MockClientInput{
+			AccountName: accountURL,
+		}),
+	}
+}
+
+const (
+	testHeaderName = "X-Test-Header"
+	testHeaderVal1 = "number one"
+	testHeaderVal2 = "number two"
+)
+
+func TestSetHeader(t *testing.T) {
+	computeClient := MockComputeClient()
+
+	do := func(ctx context.Context, cc *compute.ComputeClient) error {
+		defer testutils.DeactivateClient()
+
+		header := &http.Header{}
+		header.Add(testHeaderName, testHeaderVal1)
+		header.Add(testHeaderName, testHeaderVal2)
+		cc.SetHeader(header)
+
+		_, err := cc.Datacenters().List(ctx, &compute.ListDataCentersInput{})
+
+		return err
+	}
+
+	t.Run("override header", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountURL, "datacenters"), overrideHeaderTest(t))
+
+		err := do(context.Background(), computeClient)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}
+
+func overrideHeaderTest(t *testing.T) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get(testHeaderName) == "" {
+			t.Errorf("Request header should contain '%s'", testHeaderName)
+		}
+		testHeader := strings.Join(req.Header[testHeaderName], ",")
+		if !strings.Contains(testHeader, testHeaderVal1) {
+			t.Errorf("Request header should contain '%s': got '%s'", testHeaderVal1, testHeader)
+		}
+		if !strings.Contains(testHeader, testHeaderVal2) {
+			t.Errorf("Request header should contain '%s': got '%s'", testHeaderVal2, testHeader)
+		}
+
+		header := http.Header{}
+		header.Add("Content-Type", "application/json")
+
+		body := strings.NewReader(`{
+	"us-east-1": "https://us-east-1.api.joyentcloud.com"
+}
+`)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       ioutil.NopCloser(body),
+		}, nil
+	}
+}

--- a/compute/datacenters_test.go
+++ b/compute/datacenters_test.go
@@ -119,7 +119,7 @@ func TestAccDataCenters_List(t *testing.T) {
 }
 
 func TestListDataCenters(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.DataCenter, error) {
 		defer testutils.DeactivateClient()
@@ -189,7 +189,7 @@ func TestListDataCenters(t *testing.T) {
 }
 
 func TestGetDataCenter(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.DataCenter, error) {
 		defer testutils.DeactivateClient()

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -223,7 +223,7 @@ func TestAccImagesGet(t *testing.T) {
 }
 
 func TestDeleteImage(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -257,7 +257,7 @@ func TestDeleteImage(t *testing.T) {
 }
 
 func TestGetImage(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Image, error) {
 		defer testutils.DeactivateClient()
@@ -328,7 +328,7 @@ func TestGetImage(t *testing.T) {
 }
 
 func TestListImages(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.Image, error) {
 		defer testutils.DeactivateClient()
@@ -397,7 +397,7 @@ func TestListImages(t *testing.T) {
 }
 
 func TestCreateImageFromMachine(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Image, error) {
 		defer testutils.DeactivateClient()
@@ -437,7 +437,7 @@ func TestCreateImageFromMachine(t *testing.T) {
 }
 
 func TestUpdateImage(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Image, error) {
 		defer testutils.DeactivateClient()
@@ -477,7 +477,7 @@ func TestUpdateImage(t *testing.T) {
 }
 
 func TestExportImage(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.MantaLocation, error) {
 		defer testutils.DeactivateClient()
@@ -543,15 +543,15 @@ func getImageSuccess(req *http.Request) (*http.Response, error) {
   "type": "zone-dataset",
   "description": "A 32-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.",
   "files": [
-    {
-      "compression": "gzip",
-      "sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
-      "size": 110742036
-    }
+	{
+	  "compression": "gzip",
+	  "sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
+	  "size": 110742036
+	}
   ],
   "tags": {
-    "role": "os",
-    "group": "base-32"
+	"role": "os",
+	"group": "base-32"
   },
   "homepage": "https://docs.joyent.com/images/smartos/base",
   "published_at": "2014-02-28T10:50:42Z",
@@ -581,15 +581,15 @@ func getImageBadDecode(req *http.Request) (*http.Response, error) {
   "type": "zone-dataset",
   "description": "A 32-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.",
   "files": [
-    {
-      "compression": "gzip",
-      "sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
-      "size": 110742036
-    }
+	{
+	  "compression": "gzip",
+	  "sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
+	  "size": 110742036
+	}
   ],
   "tags": {
-    "role": "os",
-    "group": "base-32"
+	"role": "os",
+	"group": "base-32"
   },
   "homepage": "https://docs.joyent.com/images/smartos/base",
   "published_at": "2014-02-28T10:50:42Z",
@@ -626,29 +626,29 @@ func listImagesSuccess(req *http.Request) (*http.Response, error) {
 
 	body := strings.NewReader(`[
 {
-    "id": "2b683a82-a066-11e3-97ab-2faa44701c5a",
-    "name": "base",
-    "version": "13.4.0",
-    "os": "smartos",
-    "requirements": {},
-    "type": "zone-dataset",
-    "description": "A 32-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.",
-    "files": [
-      {
-        "compression": "gzip",
-        "sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
-        "size": 110742036
-      }
-    ],
-    "tags": {
-      "role": "os",
-      "group": "base-32"
-    },
-    "homepage": "https://docs.joyent.com/images/smartos/base",
-    "published_at": "2014-02-28T10:50:42Z",
-    "owner": "930896af-bf8c-48d4-885c-6573a94b1853",
-    "public": true,
-    "state": "active"
+	"id": "2b683a82-a066-11e3-97ab-2faa44701c5a",
+	"name": "base",
+	"version": "13.4.0",
+	"os": "smartos",
+	"requirements": {},
+	"type": "zone-dataset",
+	"description": "A 32-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.",
+	"files": [
+	  {
+		"compression": "gzip",
+		"sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
+		"size": 110742036
+	  }
+	],
+	"tags": {
+	  "role": "os",
+	  "group": "base-32"
+	},
+	"homepage": "https://docs.joyent.com/images/smartos/base",
+	"published_at": "2014-02-28T10:50:42Z",
+	"owner": "930896af-bf8c-48d4-885c-6573a94b1853",
+	"public": true,
+	"state": "active"
   }
 ]`)
 
@@ -675,29 +675,29 @@ func listImagesBadDecode(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`[{
-    "id": "2b683a82-a066-11e3-97ab-2faa44701c5a",
-    "name": "base",
-    "version": "13.4.0",
-    "os": "smartos",
-    "requirements": {},
-    "type": "zone-dataset",
-    "description": "A 32-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.",
-    "files": [
-      {
-        "compression": "gzip",
-        "sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
-        "size": 110742036
-      }
-    ],
-    "tags": {
-      "role": "os",
-      "group": "base-32"
-    },
-    "homepage": "https://docs.joyent.com/images/smartos/base",
-    "published_at": "2014-02-28T10:50:42Z",
-    "owner": "930896af-bf8c-48d4-885c-6573a94b1853",
-    "public": true,
-    "state": "active",
+	"id": "2b683a82-a066-11e3-97ab-2faa44701c5a",
+	"name": "base",
+	"version": "13.4.0",
+	"os": "smartos",
+	"requirements": {},
+	"type": "zone-dataset",
+	"description": "A 32-bit SmartOS image with just essential packages installed. Ideal for users who are comfortable with setting up their own environment and tools.",
+	"files": [
+	  {
+		"compression": "gzip",
+		"sha1": "3bebb6ae2cdb26eef20cfb30fdc4a00a059a0b7b",
+		"size": 110742036
+	  }
+	],
+	"tags": {
+	  "role": "os",
+	  "group": "base-32"
+	},
+	"homepage": "https://docs.joyent.com/images/smartos/base",
+	"published_at": "2014-02-28T10:50:42Z",
+	"owner": "930896af-bf8c-48d4-885c-6573a94b1853",
+	"public": true,
+	"state": "active",
   }]`)
 
 	return &http.Response{
@@ -716,13 +716,13 @@ func createImageFromMachineSuccess(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-    "id": "62306cd7-7b8a-c5dd-d44e-8491c83b9974",
-    "name": "my-custom-image",
-    "version": "1.2.3",
-    "requirements": {},
-    "owner": "47034e57-42d1-0342-b302-00db733e8c8a",
-    "public": false,
-    "state": "active"
+	"id": "62306cd7-7b8a-c5dd-d44e-8491c83b9974",
+	"name": "my-custom-image",
+	"version": "1.2.3",
+	"requirements": {},
+	"owner": "47034e57-42d1-0342-b302-00db733e8c8a",
+	"public": false,
+	"state": "active"
 }
 `)
 

--- a/compute/instances_test.go
+++ b/compute/instances_test.go
@@ -530,7 +530,7 @@ func TestValidateInstanceInput(t *testing.T) {
 }
 
 func TestGetInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Instance, error) {
 		defer testutils.DeactivateClient()
@@ -601,7 +601,7 @@ func TestGetInstance(t *testing.T) {
 }
 
 func TestListInstances(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.Instance, error) {
 		defer testutils.DeactivateClient()
@@ -672,7 +672,7 @@ func TestListInstances(t *testing.T) {
 }
 
 func TestDeleteInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -706,7 +706,7 @@ func TestDeleteInstance(t *testing.T) {
 }
 
 func TestRenameInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -741,7 +741,7 @@ func TestRenameInstance(t *testing.T) {
 }
 
 func TestRebootInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -775,7 +775,7 @@ func TestRebootInstance(t *testing.T) {
 }
 
 func TestStartInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -809,7 +809,7 @@ func TestStartInstance(t *testing.T) {
 }
 
 func TestStopInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -843,7 +843,7 @@ func TestStopInstance(t *testing.T) {
 }
 
 func TestResizeInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -878,7 +878,7 @@ func TestResizeInstance(t *testing.T) {
 }
 
 func TestEnableInstanceFirewall(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -912,7 +912,7 @@ func TestEnableInstanceFirewall(t *testing.T) {
 }
 
 func TestDisableInstanceFirewall(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -946,7 +946,7 @@ func TestDisableInstanceFirewall(t *testing.T) {
 }
 
 func TestDeleteInstanceTags(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -980,7 +980,7 @@ func TestDeleteInstanceTags(t *testing.T) {
 }
 
 func TestDeleteInstanceTag(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -1015,7 +1015,7 @@ func TestDeleteInstanceTag(t *testing.T) {
 }
 
 func TestGetInstanceTag(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (string, error) {
 		defer testutils.DeactivateClient()
@@ -1063,7 +1063,7 @@ func TestGetInstanceTag(t *testing.T) {
 }
 
 func TestListInstanceTag(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (map[string]interface{}, error) {
 		defer testutils.DeactivateClient()
@@ -1110,7 +1110,7 @@ func TestListInstanceTag(t *testing.T) {
 }
 
 func TestReplaceInstanceTags(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -1148,7 +1148,7 @@ func TestReplaceInstanceTags(t *testing.T) {
 }
 
 func TestAddInstanceTags(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -1186,7 +1186,7 @@ func TestAddInstanceTags(t *testing.T) {
 }
 
 func TestGetInstanceMetaData(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (string, error) {
 		defer testutils.DeactivateClient()
@@ -1234,7 +1234,7 @@ func TestGetInstanceMetaData(t *testing.T) {
 }
 
 func TestListInstanceMetaData(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (map[string]string, error) {
 		defer testutils.DeactivateClient()
@@ -1281,7 +1281,7 @@ func TestListInstanceMetaData(t *testing.T) {
 }
 
 func TestDeleteInstanceMetaData(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -1316,7 +1316,7 @@ func TestDeleteInstanceMetaData(t *testing.T) {
 }
 
 func TestDeleteAllInstanceMetaData(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -1350,7 +1350,7 @@ func TestDeleteAllInstanceMetaData(t *testing.T) {
 }
 
 func TestUpdateInstanceMetaData(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (map[string]string, error) {
 		defer testutils.DeactivateClient()
@@ -1393,7 +1393,7 @@ func TestUpdateInstanceMetaData(t *testing.T) {
 }
 
 func TestListInstanceNICs(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.NIC, error) {
 		defer testutils.DeactivateClient()
@@ -1464,7 +1464,7 @@ func TestListInstanceNICs(t *testing.T) {
 }
 
 func TestGetInstanceNIC(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.NIC, error) {
 		defer testutils.DeactivateClient()
@@ -1536,7 +1536,7 @@ func TestGetInstanceNIC(t *testing.T) {
 }
 
 func TestRemoveInstanceNIC(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -1571,7 +1571,7 @@ func TestRemoveInstanceNIC(t *testing.T) {
 }
 
 func TestAddNICToInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.NIC, error) {
 		defer testutils.DeactivateClient()
@@ -1611,7 +1611,7 @@ func TestAddNICToInstance(t *testing.T) {
 }
 
 func TestCreateInstance(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Instance, error) {
 		defer testutils.DeactivateClient()
@@ -1661,20 +1661,20 @@ func getMachineSuccess(req *http.Request) (*http.Response, error) {
   "state": "running",
   "image": "2b683a82-a066-11e3-97ab-2faa44701c5a",
   "ips": [
-    "10.88.88.26",
-    "192.168.128.5"
+	"10.88.88.26",
+	"192.168.128.5"
   ],
   "memory": 128,
   "disk": 12288,
   "metadata": {
-    "root_authorized_keys": "..."
+	"root_authorized_keys": "..."
   },
   "tags": {},
   "created": "2016-01-04T12:55:50.539Z",
   "updated": "2016-01-21T08:56:59.000Z",
   "networks": [
-    "a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
-    "45607081-4cd2-45c8-baf7-79da760fffaa"
+	"a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
+	"45607081-4cd2-45c8-baf7-79da760fffaa"
   ],
   "primaryIp": "10.88.88.26",
   "firewall_enabled": false,
@@ -1702,20 +1702,20 @@ func getMachineBadDecode(req *http.Request) (*http.Response, error) {
   "state": "running",
   "image": "2b683a82-a066-11e3-97ab-2faa44701c5a",
   "ips": [
-    "10.88.88.26",
-    "192.168.128.5"
+	"10.88.88.26",
+	"192.168.128.5"
   ],
   "memory": 128,
   "disk": 12288,
   "metadata": {
-    "root_authorized_keys": "...",
+	"root_authorized_keys": "...",
   },
   "tags": {},
   "created": "2016-01-04T12:55:50.539Z",
   "updated": "2016-01-21T08:56:59.000Z",
   "networks": [
-    "a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
-    "45607081-4cd2-45c8-baf7-79da760fffaa"
+	"a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
+	"45607081-4cd2-45c8-baf7-79da760fffaa"
   ],
   "primaryIp": "10.88.88.26",
   "firewall_enabled": false,
@@ -1751,32 +1751,32 @@ func listMachinesSuccess(req *http.Request) (*http.Response, error) {
 
 	body := strings.NewReader(`[
 	{
-    "id": "b6979942-7d5d-4fe6-a2ec-b812e950625a",
-    "name": "test",
-    "type": "smartmachine",
-    "brand": "joyent",
-    "state": "running",
-    "image": "2b683a82-a066-11e3-97ab-2faa44701c5a",
-    "ips": [
-      "10.88.88.26",
-      "192.168.128.5"
-    ],
-    "memory": 128,
-    "disk": 12288,
-    "metadata": {
-      "root_authorized_keys": "..."
-    },
-    "tags": {},
-    "created": "2016-01-04T12:55:50.539Z",
-    "updated": "2016-01-21T08:56:59.000Z",
-    "networks": [
-      "a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
-      "45607081-4cd2-45c8-baf7-79da760fffaa"
-    ],
-    "primaryIp": "10.88.88.26",
-    "firewall_enabled": false,
-    "compute_node": "564d0b8e-6099-7648-351e-877faf6c56f6",
-    "package": "sdc_128"
+	"id": "b6979942-7d5d-4fe6-a2ec-b812e950625a",
+	"name": "test",
+	"type": "smartmachine",
+	"brand": "joyent",
+	"state": "running",
+	"image": "2b683a82-a066-11e3-97ab-2faa44701c5a",
+	"ips": [
+	  "10.88.88.26",
+	  "192.168.128.5"
+	],
+	"memory": 128,
+	"disk": 12288,
+	"metadata": {
+	  "root_authorized_keys": "..."
+	},
+	"tags": {},
+	"created": "2016-01-04T12:55:50.539Z",
+	"updated": "2016-01-21T08:56:59.000Z",
+	"networks": [
+	  "a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
+	  "45607081-4cd2-45c8-baf7-79da760fffaa"
+	],
+	"primaryIp": "10.88.88.26",
+	"firewall_enabled": false,
+	"compute_node": "564d0b8e-6099-7648-351e-877faf6c56f6",
+	"package": "sdc_128"
   }
 ]`)
 
@@ -1803,32 +1803,32 @@ func listMachinesBadDecode(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`[{
-    "id": "b6979942-7d5d-4fe6-a2ec-b812e950625a",
-    "name": "test",
-    "type": "smartmachine",
-    "brand": "joyent",
-    "state": "running",
-    "image": "2b683a82-a066-11e3-97ab-2faa44701c5a",
-    "ips": [
-      "10.88.88.26",
-      "192.168.128.5"
-    ],
-    "memory": 128,
-    "disk": 12288,
-    "metadata": {
-      "root_authorized_keys": "..."
-    },
-    "tags": {},
-    "created": "2016-01-04T12:55:50.539Z",
-    "updated": "2016-01-21T08:56:59.000Z",
-    "networks": [
-      "a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
-      "45607081-4cd2-45c8-baf7-79da760fffaa"
-    ],
-    "primaryIp": "10.88.88.26",
-    "firewall_enabled": false,
-    "compute_node": "564d0b8e-6099-7648-351e-877faf6c56f6",
-    "package": "sdc_128",
+	"id": "b6979942-7d5d-4fe6-a2ec-b812e950625a",
+	"name": "test",
+	"type": "smartmachine",
+	"brand": "joyent",
+	"state": "running",
+	"image": "2b683a82-a066-11e3-97ab-2faa44701c5a",
+	"ips": [
+	  "10.88.88.26",
+	  "192.168.128.5"
+	],
+	"memory": 128,
+	"disk": 12288,
+	"metadata": {
+	  "root_authorized_keys": "..."
+	},
+	"tags": {},
+	"created": "2016-01-04T12:55:50.539Z",
+	"updated": "2016-01-21T08:56:59.000Z",
+	"networks": [
+	  "a9c130da-e3ba-40e9-8b18-112aba2d3ba7",
+	  "45607081-4cd2-45c8-baf7-79da760fffaa"
+	],
+	"primaryIp": "10.88.88.26",
+	"firewall_enabled": false,
+	"compute_node": "564d0b8e-6099-7648-351e-877faf6c56f6",
+	"package": "sdc_128",
   }]`)
 
 	return &http.Response{
@@ -2086,14 +2086,14 @@ func listMachineNICsSuccess(req *http.Request) (*http.Response, error) {
 
 	body := strings.NewReader(`[
 	{
-        "mac": "90:b8:d0:2f:b8:f9",
-        "primary": true,
-        "ip": "10.88.88.137",
-        "netmask": "255.255.255.0",
-        "gateway": "10.88.88.2",
-        "state": "running",
-        "network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35"
-    }
+		"mac": "90:b8:d0:2f:b8:f9",
+		"primary": true,
+		"ip": "10.88.88.137",
+		"netmask": "255.255.255.0",
+		"gateway": "10.88.88.2",
+		"state": "running",
+		"network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35"
+	}
 ]`)
 
 	return &http.Response{
@@ -2119,14 +2119,14 @@ func listMachineNICsBadDecode(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`[{
-        "mac": "90:b8:d0:2f:b8:f9",
-        "primary": true,
-        "ip": "10.88.88.137",
-        "netmask": "255.255.255.0",
-        "gateway": "10.88.88.2",
-        "state": "running",
-        "network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35",
-    }]`)
+		"mac": "90:b8:d0:2f:b8:f9",
+		"primary": true,
+		"ip": "10.88.88.137",
+		"netmask": "255.255.255.0",
+		"gateway": "10.88.88.2",
+		"state": "running",
+		"network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35",
+	}]`)
 
 	return &http.Response{
 		StatusCode: http.StatusOK,
@@ -2144,14 +2144,14 @@ func getMachineNICSuccess(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-        "mac": "90:b8:d0:2f:b8:f9",
-        "primary": true,
-        "ip": "10.88.88.137",
-        "netmask": "255.255.255.0",
-        "gateway": "10.88.88.2",
-        "state": "running",
-        "network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35"
-    }
+		"mac": "90:b8:d0:2f:b8:f9",
+		"primary": true,
+		"ip": "10.88.88.137",
+		"netmask": "255.255.255.0",
+		"gateway": "10.88.88.2",
+		"state": "running",
+		"network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35"
+	}
 `)
 
 	return &http.Response{
@@ -2166,14 +2166,14 @@ func getMachineNICBadDecode(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-        "mac": "90:b8:d0:2f:b8:f9",
-        "primary": true,
-        "ip": "10.88.88.137",
-        "netmask": "255.255.255.0",
-        "gateway": "10.88.88.2",
-        "state": "running",
-        "network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35",
-    }`)
+		"mac": "90:b8:d0:2f:b8:f9",
+		"primary": true,
+		"ip": "10.88.88.137",
+		"netmask": "255.255.255.0",
+		"gateway": "10.88.88.2",
+		"state": "running",
+		"network": "6b3229b6-c535-11e5-8cf9-c3a24fa96e35",
+	}`)
 
 	return &http.Response{
 		StatusCode: http.StatusOK,
@@ -2216,7 +2216,7 @@ func createMachineNICSuccess(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-    "network": "7007b198-f6aa-48f0-9843-78a3149de3d7"
+	"network": "7007b198-f6aa-48f0-9843-78a3149de3d7"
 }
 `)
 
@@ -2246,7 +2246,7 @@ func createMachineSuccess(req *http.Request) (*http.Response, error) {
   "memory": 128,
   "disk": 12288,
   "metadata": {
-    "root_authorized_keys": "..."
+	"root_authorized_keys": "..."
   },
   "tags": {},
   "created": "2016-01-21T12:57:52.759Z",

--- a/compute/packages_test.go
+++ b/compute/packages_test.go
@@ -118,7 +118,7 @@ func TestAccPackagesList(t *testing.T) {
 }
 
 func TestListPackages(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.Package, error) {
 		defer testutils.DeactivateClient()
@@ -208,7 +208,7 @@ func TestListPackages(t *testing.T) {
 }
 
 func TestGetPackage(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Package, error) {
 		defer testutils.DeactivateClient()

--- a/compute/ping_test.go
+++ b/compute/ping_test.go
@@ -146,11 +146,3 @@ func pingDecodeFunc(req *http.Request) (*http.Response, error) {
 		Body:       ioutil.NopCloser(body),
 	}, nil
 }
-
-func MockComputeClient() *compute.ComputeClient {
-	return &compute.ComputeClient{
-		Client: testutils.NewMockClient(testutils.MockClientInput{
-			AccountName: accountURL,
-		}),
-	}
-}

--- a/compute/services_test.go
+++ b/compute/services_test.go
@@ -77,7 +77,7 @@ func TestAccServicesList(t *testing.T) {
 }
 
 func TestListServices(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.Service, error) {
 		defer testutils.DeactivateClient()

--- a/compute/snapshots_test.go
+++ b/compute/snapshots_test.go
@@ -32,16 +32,8 @@ var (
 	testMachineId                     = "123-3456-2335"
 )
 
-func MockIdentityClient() *compute.ComputeClient {
-	return &compute.ComputeClient{
-		Client: testutils.NewMockClient(testutils.MockClientInput{
-			AccountName: accountURL,
-		}),
-	}
-}
-
 func TestListSnapshots(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.Snapshot, error) {
 		defer testutils.DeactivateClient()
@@ -112,7 +104,7 @@ func TestListSnapshots(t *testing.T) {
 }
 
 func TestGetSnapshot(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Snapshot, error) {
 		defer testutils.DeactivateClient()
@@ -184,7 +176,7 @@ func TestGetSnapshot(t *testing.T) {
 }
 
 func TestDeleteSnapshot(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -219,7 +211,7 @@ func TestDeleteSnapshot(t *testing.T) {
 }
 
 func TestStartMachineFromSnapshot(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -254,7 +246,7 @@ func TestStartMachineFromSnapshot(t *testing.T) {
 }
 
 func TestCreateSnapshot(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Snapshot, error) {
 		defer testutils.DeactivateClient()
@@ -298,16 +290,16 @@ func listSnapshotsSuccess(req *http.Request) (*http.Response, error) {
 
 	body := strings.NewReader(`[
 	{
-    "name": "sample-snapshot",
+	"name": "sample-snapshot",
 	"state": "queued",
-    "updated": "2015-12-23T06:41:11.032Z",
-    "created": "2015-12-23T06:41:11.032Z"
+	"updated": "2015-12-23T06:41:11.032Z",
+	"created": "2015-12-23T06:41:11.032Z"
   },
   {
-    "name": "sample-snapshot-2",
+	"name": "sample-snapshot-2",
 	"state": "queued",
-    "updated": "2015-12-23T06:41:11.032Z",
-    "created": "2015-12-23T06:41:11.032Z"
+	"updated": "2015-12-23T06:41:11.032Z",
+	"created": "2015-12-23T06:41:11.032Z"
   }
 ]`)
 
@@ -334,10 +326,10 @@ func listSnapshotBadDecode(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`[{
-    "name": "sample-snapshot",
+	"name": "sample-snapshot",
 	"state": "queued",
-    "updated": "2015-12-23T06:41:11.032Z",
-    "created": "2015-12-23T06:41:11.032Z",}]`)
+	"updated": "2015-12-23T06:41:11.032Z",
+	"created": "2015-12-23T06:41:11.032Z",}]`)
 
 	return &http.Response{
 		StatusCode: 200,
@@ -355,10 +347,10 @@ func getSnapshotSuccess(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-    "name": "sample-snapshot",
+	"name": "sample-snapshot",
 	"state": "queued",
-    "updated": "2015-12-23T06:41:11.032Z",
-    "created": "2015-12-23T06:41:11.032Z"
+	"updated": "2015-12-23T06:41:11.032Z",
+	"created": "2015-12-23T06:41:11.032Z"
   }
 `)
 
@@ -374,10 +366,10 @@ func getSnapshotBadDecode(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-    "name": "sample-snapshot",
+	"name": "sample-snapshot",
 	"state": "queued",
-    "updated": "2015-12-23T06:41:11.032Z",
-    "created": "2015-12-23T06:41:11.032Z",}`)
+	"updated": "2015-12-23T06:41:11.032Z",
+	"created": "2015-12-23T06:41:11.032Z",}`)
 
 	return &http.Response{
 		StatusCode: 200,
@@ -434,10 +426,10 @@ func createSnapshotSuccess(req *http.Request) (*http.Response, error) {
 	header.Add("Content-Type", "application/json")
 
 	body := strings.NewReader(`{
-    "name": "sample-snapshot",
+	"name": "sample-snapshot",
 	"state": "queued",
-    "updated": "2015-12-23T06:41:11.032Z",
-    "created": "2015-12-23T06:41:11.032Z"
+	"updated": "2015-12-23T06:41:11.032Z",
+	"created": "2015-12-23T06:41:11.032Z"
   }
 `)
 

--- a/compute/volumes_test.go
+++ b/compute/volumes_test.go
@@ -24,7 +24,7 @@ import (
 const fakeVolumeID = "1fd4ecb9-7f66-cf31-9a8a-b661d3adebcf"
 
 func TestGetVolume(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Volume, error) {
 		defer testutils.DeactivateClient()
@@ -95,7 +95,7 @@ func TestGetVolume(t *testing.T) {
 }
 
 func TestDeleteVolume(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -129,7 +129,7 @@ func TestDeleteVolume(t *testing.T) {
 }
 
 func TestCreateVolume(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Volume, error) {
 		defer testutils.DeactivateClient()
@@ -169,7 +169,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestUpdateVolume(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) error {
 		defer testutils.DeactivateClient()
@@ -204,7 +204,7 @@ func TestUpdateVolume(t *testing.T) {
 }
 
 func TestListVolumes(t *testing.T) {
-	computeClient := MockIdentityClient()
+	computeClient := MockComputeClient()
 
 	do := func(ctx context.Context, cc *compute.ComputeClient) ([]*compute.Volume, error) {
 		defer testutils.DeactivateClient()

--- a/identity/client.go
+++ b/identity/client.go
@@ -9,6 +9,8 @@
 package identity
 
 import (
+	"net/http"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/client"
 )
@@ -32,6 +34,12 @@ func NewClient(config *triton.ClientConfig) (*IdentityClient, error) {
 		return nil, err
 	}
 	return newIdentityClient(client), nil
+}
+
+// SetHeaders allows a consumer of the current client to set custom headers for
+// the next backend HTTP request sent to CloudAPI
+func (c *IdentityClient) SetHeader(header *http.Header) {
+	c.Client.RequestHeader = header
 }
 
 // Roles returns a Roles client used for accessing functions pertaining to

--- a/network/client.go
+++ b/network/client.go
@@ -9,6 +9,8 @@
 package network
 
 import (
+	"net/http"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/client"
 )
@@ -32,6 +34,12 @@ func NewClient(config *triton.ClientConfig) (*NetworkClient, error) {
 		return nil, err
 	}
 	return newNetworkClient(client), nil
+}
+
+// SetHeaders allows a consumer of the current client to set custom headers for
+// the next backend HTTP request sent to CloudAPI
+func (c *NetworkClient) SetHeader(header *http.Header) {
+	c.Client.RequestHeader = header
 }
 
 // Fabrics returns a FabricsClient used for accessing functions pertaining to

--- a/storage/client.go
+++ b/storage/client.go
@@ -9,6 +9,8 @@
 package storage
 
 import (
+	"net/http"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/client"
 )
@@ -32,6 +34,12 @@ func NewClient(config *triton.ClientConfig) (*StorageClient, error) {
 		return nil, err
 	}
 	return newStorageClient(client), nil
+}
+
+// SetHeader allows a consumer of the current client to set a custom header for
+// the next backend HTTP request sent to CloudAPI.
+func (c *StorageClient) SetHeader(header *http.Header) {
+	c.Client.RequestHeader = header
 }
 
 // Dir returns a DirectoryClient used for accessing functions pertaining to


### PR DESCRIPTION
Ref: #124 

This is required to override HTTP signature authentication with "manual" values.

Also, rename `MockIdentityClient()` => `MockComputeClient()` within the `compute` package.