### PR TITLE
root: Move GetTritonEnv into root triton package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/joyent/triton-go"
@@ -103,29 +102,12 @@ func New(tritonURL string, mantaURL string, accountName string, signers ...authe
 	return newClient, nil
 }
 
-var envPrefixes = []string{"TRITON", "SDC"}
-
-// GetTritonEnv looks up environment variables using the preferred "TRITON"
-// prefix, but falls back to the SDC prefix.  For example, looking up "USER"
-// will search for "TRITON_USER" followed by "SDC_USER".  If the environment
-// variable is not set, an empty string is returned.  GetTritonEnv() is used to
-// aid in the transition and deprecation of the SDC_* environment variables.
-func GetTritonEnv(name string) string {
-	for _, prefix := range envPrefixes {
-		if val, found := os.LookupEnv(prefix + "_" + name); found {
-			return val
-		}
-	}
-
-	return ""
-}
-
 // initDefaultAuth provides a default key signer for a client. This should only
 // be used internally if the client has no other key signer for authenticating
 // with Triton. We first look for both `SDC_KEY_ID` and `SSH_AUTH_SOCK` in the
 // user's environ(7). If so we default to the SSH agent key signer.
 func (c *Client) DefaultAuth() error {
-	tritonKeyId := GetTritonEnv("KEY_ID")
+	tritonKeyId := triton.GetEnv("KEY_ID")
 	if tritonKeyId != "" {
 		input := authentication.SSHAgentSignerInput{
 			KeyID:       tritonKeyId,

--- a/testutils/runner.go
+++ b/testutils/runner.go
@@ -17,7 +17,6 @@ import (
 
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
-	"github.com/joyent/triton-go/client"
 )
 
 const TestEnvVar = "TRITON_TEST"
@@ -43,12 +42,12 @@ func AccTest(t *testing.T, c TestCase) {
 		return
 	}
 
-	tritonURL := client.GetTritonEnv("URL")
-	tritonAccount := client.GetTritonEnv("ACCOUNT")
-	tritonKeyID := client.GetTritonEnv("KEY_ID")
-	tritonKeyMaterial := client.GetTritonEnv("KEY_MATERIAL")
-	userName := client.GetTritonEnv("USER")
-	mantaURL := client.GetTritonEnv("MANTA_URL")
+	tritonURL := triton.GetEnv("URL")
+	tritonAccount := triton.GetEnv("ACCOUNT")
+	tritonKeyID := triton.GetEnv("KEY_ID")
+	tritonKeyMaterial := triton.GetEnv("KEY_MATERIAL")
+	userName := triton.GetEnv("USER")
+	mantaURL := triton.GetEnv("MANTA_URL")
 
 	var prerollErrors []error
 	if tritonURL == "" {

--- a/triton.go
+++ b/triton.go
@@ -9,6 +9,8 @@
 package triton
 
 import (
+	"os"
+
 	"github.com/joyent/triton-go/authentication"
 )
 
@@ -24,4 +26,21 @@ type ClientConfig struct {
 	AccountName string
 	Username    string
 	Signers     []authentication.Signer
+}
+
+var envPrefixes = []string{"TRITON", "SDC"}
+
+// GetEnv looks up environment variables using the preferred "TRITON" prefix,
+// but falls back to the retired "SDC" prefix.  For example, looking up "USER"
+// will search for "TRITON_USER" followed by "SDC_USER".  If the environment
+// variable is not set, an empty string is returned.  GetEnv() is used to aid in
+// the transition and deprecation of the "SDC_*" environment variables.
+func GetEnv(name string) string {
+	for _, prefix := range envPrefixes {
+		if val, found := os.LookupEnv(prefix + "_" + name); found {
+			return val
+		}
+	}
+
+	return ""
 }

--- a/triton_test.go
+++ b/triton_test.go
@@ -1,0 +1,33 @@
+package triton_test
+
+import (
+	"os"
+	"testing"
+
+	triton "github.com/joyent/triton-go"
+)
+
+func TestGetEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		varname string
+		input   string
+		value   string
+	}{
+		{"Triton", "TRITON_NAME", "NAME", "good"},
+		{"SDC", "SDC_NAME", "NAME", "good"},
+		{"unrelated", "BAD_NAME", "NAME", ""},
+		{"missing", "", "NAME", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv(test.varname, test.value)
+			defer os.Unsetenv(test.varname)
+
+			if val := triton.GetEnv(test.input); val != test.value {
+				t.Errorf("expected %s env var to be '%s': got '%s'",
+					test.varname, test.value, val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Something I noticed while working on `triton-go` lately is that we should probably rename `client.GetTritonEnv` => `triton.GetEnv`. This will help maintain our environment variable configuration at the root of the project for easier consumption. I've also added a unit test.