### PR TITLE
compute/instances: Add missing Close() for the response body.

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -245,6 +245,9 @@ func (c *InstancesClient) List(ctx context.Context, input *ListInstancesInput) (
 		Query:  buildQueryFilter(input),
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "unable to list machines")
 	}


### PR DESCRIPTION
This commit adds missing call to the `Close()` method for the underlying
`io.ReadCloser` interface, which an cause a potential memory leak.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>