### PR TITLE
Manta RBAC authentication support.

### DIFF
--- a/authentication/agent_key_identifier.go
+++ b/authentication/agent_key_identifier.go
@@ -1,0 +1,25 @@
+package authentication
+
+import "path"
+
+type KeyID struct {
+	UserName    string
+	AccountName string
+	Fingerprint string
+	IsManta     bool
+}
+
+func (input *KeyID) generate() string {
+	var keyID string
+	if input.UserName != "" {
+		if input.IsManta {
+			keyID = path.Join("/", input.AccountName, input.UserName, "keys", input.Fingerprint)
+		} else {
+			keyID = path.Join("/", input.AccountName, "users", input.UserName, "keys", input.Fingerprint)
+		}
+	} else {
+		keyID = path.Join("/", input.AccountName, "keys", input.Fingerprint)
+	}
+
+	return keyID
+}

--- a/authentication/signer.go
+++ b/authentication/signer.go
@@ -13,6 +13,6 @@ const authorizationHeaderFormat = `Signature keyId="%s",algorithm="%s",headers="
 type Signer interface {
 	DefaultAlgorithm() string
 	KeyFingerprint() string
-	Sign(dateHeader string) (string, error)
+	Sign(dateHeader string, isManta bool) (string, error)
 	SignRaw(toSign string) (string, string, error)
 }

--- a/authentication/ssh_agent_signer.go
+++ b/authentication/ssh_agent_signer.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"strings"
 
 	pkgerrors "github.com/pkg/errors"
@@ -70,12 +69,6 @@ func NewSSHAgentSigner(input SSHAgentSignerInput) (*SSHAgentSigner, error) {
 	}
 	signer.key = matchingKey
 	signer.formattedKeyFingerprint = formatPublicKeyFingerprint(signer.key, true)
-	if input.Username != "" {
-		signer.userName = input.Username
-		signer.keyIdentifier = path.Join("/", signer.accountName, "users", input.Username, "keys", signer.formattedKeyFingerprint)
-	} else {
-		signer.keyIdentifier = path.Join("/", signer.accountName, "keys", signer.formattedKeyFingerprint)
-	}
 
 	_, algorithm, err := signer.SignRaw("HelloWorld")
 	if err != nil {
@@ -118,7 +111,7 @@ func (s *SSHAgentSigner) MatchKey() (ssh.PublicKey, error) {
 	return matchingKey, nil
 }
 
-func (s *SSHAgentSigner) Sign(dateHeader string) (string, error) {
+func (s *SSHAgentSigner) Sign(dateHeader string, isManta bool) (string, error) {
 	const headerName = "date"
 
 	signature, err := s.agent.Sign(s.key, []byte(fmt.Sprintf("%s: %s", headerName, dateHeader)))
@@ -129,6 +122,13 @@ func (s *SSHAgentSigner) Sign(dateHeader string) (string, error) {
 	keyFormat, err := keyFormatToKeyType(signature.Format)
 	if err != nil {
 		return "", pkgerrors.Wrap(err, "unable to format signature")
+	}
+
+	key := &KeyID{
+		UserName:    s.userName,
+		AccountName: s.accountName,
+		Fingerprint: s.formattedKeyFingerprint,
+		IsManta:     isManta,
 	}
 
 	var authSignature httpAuthSignature
@@ -147,7 +147,7 @@ func (s *SSHAgentSigner) Sign(dateHeader string) (string, error) {
 		return "", fmt.Errorf("Unsupported algorithm from SSH agent: %s", signature.Format)
 	}
 
-	return fmt.Sprintf(authorizationHeaderFormat, s.keyIdentifier,
+	return fmt.Sprintf(authorizationHeaderFormat, key.generate(),
 		authSignature.SignatureType(), headerName, authSignature.String()), nil
 }
 

--- a/authentication/test_signer.go
+++ b/authentication/test_signer.go
@@ -26,7 +26,7 @@ func (s *TestSigner) KeyFingerprint() string {
 	return ""
 }
 
-func (s *TestSigner) Sign(dateHeader string) (string, error) {
+func (s *TestSigner) Sign(dateHeader string, isManta bool) (string, error) {
 	return "", nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -238,7 +238,7 @@ func (c *Client) ExecuteRequestURIParams(ctx context.Context, inputs RequestInpu
 
 	// NewClient ensures there's always an authorizer (unless this is called
 	// outside that constructor).
-	authHeader, err := c.Authorizers[0].Sign(dateHeader)
+	authHeader, err := c.Authorizers[0].Sign(dateHeader, false)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "unable to sign HTTP request")
 	}
@@ -304,7 +304,7 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 
 	// NewClient ensures there's always an authorizer (unless this is called
 	// outside that constructor).
-	authHeader, err := c.Authorizers[0].Sign(dateHeader)
+	authHeader, err := c.Authorizers[0].Sign(dateHeader, false)
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "unable to sign HTTP request")
 	}
@@ -373,7 +373,7 @@ func (c *Client) ExecuteRequestStorage(ctx context.Context, inputs RequestInput)
 	dateHeader := time.Now().UTC().Format(time.RFC1123)
 	req.Header.Set("date", dateHeader)
 
-	authHeader, err := c.Authorizers[0].Sign(dateHeader)
+	authHeader, err := c.Authorizers[0].Sign(dateHeader, true)
 	if err != nil {
 		return nil, nil, pkgerrors.Wrapf(err, "unable to sign HTTP request")
 	}
@@ -437,7 +437,7 @@ func (c *Client) ExecuteRequestNoEncode(ctx context.Context, inputs RequestNoEnc
 	dateHeader := time.Now().UTC().Format(time.RFC1123)
 	req.Header.Set("date", dateHeader)
 
-	authHeader, err := c.Authorizers[0].Sign(dateHeader)
+	authHeader, err := c.Authorizers[0].Sign(dateHeader, true)
 	if err != nil {
 		return nil, nil, pkgerrors.Wrapf(err, "unable to sign HTTP request")
 	}


### PR DESCRIPTION
The RBAC HTTP Signatures between manta and triton are slightly different

Therefore, we need to generate the signature based on whether the request
is for RBAC AND for Manta or not

We therefore, moved the logic to a central generate func rather than being
handled different;y between private key and ssh agent signers

Paired on this with @cheapRoc