### PR TITLE
client: overrideHeader needs to use Header.Set not Header.Add

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -181,7 +181,7 @@ func (c *Client) overrideHeader(req *http.Request) {
 	if c.RequestHeader != nil {
 		for k, vs := range *c.RequestHeader {
 			for _, v := range vs {
-				req.Header.Add(k, v)
+				req.Header.Set(k, v)
 			}
 		}
 	}

--- a/compute/client_test.go
+++ b/compute/client_test.go
@@ -56,15 +56,24 @@ func TestSetHeader(t *testing.T) {
 
 func overrideHeaderTest(t *testing.T) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
+		// test existence of custom headers at all
 		if req.Header.Get(testHeaderName) == "" {
-			t.Errorf("Request header should contain '%s'", testHeaderName)
+			t.Errorf("request header should contain '%s'", testHeaderName)
 		}
+
 		testHeader := strings.Join(req.Header[testHeaderName], ",")
-		if !strings.Contains(testHeader, testHeaderVal1) {
-			t.Errorf("Request header should contain '%s': got '%s'", testHeaderVal1, testHeader)
+
+		// test length of headers
+		if size := len(req.Header[testHeaderName]); size != 1 {
+			t.Errorf("request header length is not one: got %q", testHeader)
 		}
+		// test override of initial header
+		if strings.Contains(testHeader, testHeaderVal1) {
+			t.Errorf("request header should not contain %q: got %q", testHeaderVal1, testHeader)
+		}
+		// test that final header is the one that is set
 		if !strings.Contains(testHeader, testHeaderVal2) {
-			t.Errorf("Request header should contain '%s': got '%s'", testHeaderVal2, testHeader)
+			t.Errorf("request header should contain %q: got %q", testHeaderVal2, testHeader)
 		}
 
 		header := http.Header{}


### PR DESCRIPTION
Small change needed to fix an issue with TSG submitting requests to CloudAPI. `Header.Add` was creating duplicate and empty headers which CloudAPI (justifiably) denies. Since the name of the method is `override` header (and this is a hack to get some functionality working anyway) I'm ok with changing it to `Header.Set`.