### PR TITLE
cli/account: Add the ability to manage Triton account from CLI

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -81,7 +81,7 @@ type UpdateInput struct {
 func (c AccountClient) Update(ctx context.Context, input *UpdateInput) (*Account, error) {
 	fullPath := path.Join("/", c.Client.AccountName)
 	reqInputs := client.RequestInput{
-		Method: http.MethodPut,
+		Method: http.MethodPost,
 		Path:   fullPath,
 		Body:   input,
 	}

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -151,7 +151,7 @@ func TestUpdateAccount(t *testing.T) {
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("PUT", path.Join("/", accountUrl), updateAccountSuccess)
+		testutils.RegisterResponder("POST", path.Join("/", accountUrl), updateAccountSuccess)
 
 		_, err := do(context.Background(), accountClient)
 		if err != nil {
@@ -160,7 +160,7 @@ func TestUpdateAccount(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		testutils.RegisterResponder("PUT", path.Join("/", accountUrl), updateAccountError)
+		testutils.RegisterResponder("POST", path.Join("/", accountUrl), updateAccountError)
 
 		_, err := do(context.Background(), accountClient)
 		if err == nil {

--- a/cmd/agent/account/public.go
+++ b/cmd/agent/account/public.go
@@ -9,16 +9,104 @@
 package account
 
 import (
+	"context"
+
+	"strconv"
+
 	"github.com/joyent/triton-go/account"
+	tac "github.com/joyent/triton-go/account"
 	"github.com/joyent/triton-go/cmd/config"
 	"github.com/pkg/errors"
 )
 
-func NewGetAccountClient(cfg *config.TritonClientConfig) (*account.AccountClient, error) {
+type AgentAccountClient struct {
+	client *tac.AccountClient
+}
+
+func NewAccountClient(cfg *config.TritonClientConfig) (*AgentAccountClient, error) {
 	accountClient, err := account.NewClient(cfg.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error Creating Triton Account Client")
 	}
 
-	return accountClient, nil
+	return &AgentAccountClient{
+		client: accountClient,
+	}, nil
+}
+
+func (c *AgentAccountClient) Get() (*tac.Account, error) {
+	account, err := c.client.Get(context.Background(), &tac.GetInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
+}
+
+func (c *AgentAccountClient) UpdateAccount() (*tac.Account, error) {
+
+	params := &tac.UpdateInput{}
+
+	email := config.GetAccountEmail()
+	if email != "" {
+		params.Email = email
+	}
+
+	companyName := config.GetAccountCompanyName()
+	if companyName != "" {
+		params.CompanyName = companyName
+	}
+
+	firstName := config.GetAccountFirstName()
+	if firstName != "" {
+		params.FirstName = firstName
+	}
+
+	lastName := config.GetAccountLastName()
+	if lastName != "" {
+		params.LastName = lastName
+	}
+
+	address := config.GetAccountAddress()
+	if address != "" {
+		params.Address = address
+	}
+
+	postalCode := config.GetAccountPostalCode()
+	if postalCode != "" {
+		params.PostalCode = postalCode
+	}
+
+	city := config.GetAccountCity()
+	if city != "" {
+		params.City = city
+	}
+
+	state := config.GetAccountState()
+	if state != "" {
+		params.State = state
+	}
+
+	country := config.GetAccountCountry()
+	if country != "" {
+		params.Country = country
+	}
+
+	phone := config.GetAccountPhone()
+	if phone != "" {
+		params.Phone = phone
+	}
+
+	cnsEnabled := config.GetAccountCNSEnabled()
+	if cnsEnabled != "" {
+		b, _ := strconv.ParseBool(cnsEnabled)
+		params.TritonCNSEnabled = b
+	}
+
+	account, err := c.client.Update(context.Background(), params)
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
@@ -347,6 +348,95 @@ func GetMachineUserdata() string {
 	return viper.GetString(config.KeyInstanceUserdata)
 }
 
+func GetAccountEmail() string {
+	return viper.GetString(config.KeyAccountEmail)
+}
+
+func GetAccountCompanyName() string {
+	return viper.GetString(config.KeyAccountCompanyName)
+}
+
+func GetAccountFirstName() string {
+	return viper.GetString(config.KeyAccountFirstName)
+}
+
+func GetAccountLastName() string {
+	return viper.GetString(config.KeyAccountLastName)
+}
+
+func GetAccountAddress() string {
+	return viper.GetString(config.KeyAccountAddress)
+}
+
+func GetAccountPostalCode() string {
+	return viper.GetString(config.KeyAccountPostcode)
+}
+
+func GetAccountCity() string {
+	return viper.GetString(config.KeyAccountCity)
+}
+
+func GetAccountState() string {
+	return viper.GetString(config.KeyAccountState)
+}
+
+func GetAccountCountry() string {
+	return viper.GetString(config.KeyAccountCountry)
+}
+
+func GetAccountPhone() string {
+	return viper.GetString(config.KeyAccountPhone)
+}
+
+func GetAccountCNSEnabled() string {
+	return viper.GetString(config.KeyAccountTritonCNSEnabled)
+}
+
 func IsBlockingAction() bool {
 	return viper.GetBool(config.KeyInstanceWait)
+}
+
+func FormatTime(t time.Time) string {
+	d := time.Since(t)
+
+	timeSegs := make([]string, 0, 6)
+
+	years := int64(float64(d/(24*time.Hour)) / 365.25)
+	if years > 0 {
+		timeSegs = append(timeSegs, fmt.Sprintf("%2dy", years))
+	}
+
+	months := int64(float64(d/(24*time.Hour)%365) / 30.25)
+	if months > 0 {
+		timeSegs = append(timeSegs, fmt.Sprintf("%2dmo", months))
+	}
+
+	days := int64(d/(24*time.Hour)) % 365 % 7
+	if days > 0 {
+		timeSegs = append(timeSegs, fmt.Sprintf("%2dd", days))
+	}
+
+	hours := int64(d.Hours()) % 24
+	if hours > 0 {
+		timeSegs = append(timeSegs, fmt.Sprintf("%2dh", hours))
+	}
+
+	minutes := int64(d.Minutes()) % 60
+	if minutes > 0 {
+		timeSegs = append(timeSegs, fmt.Sprintf("%2dm", minutes))
+	}
+
+	seconds := int64(d.Seconds()) % 60
+	if seconds > 0 {
+		timeSegs = append(timeSegs, fmt.Sprintf("%2ds", seconds))
+	}
+
+	maxSegs := len(timeSegs)
+	if maxSegs > 1 {
+		maxSegs = 1
+	}
+
+	timeSegs = timeSegs[0:maxSegs]
+
+	return strings.Join(timeSegs, " ")
 }

--- a/cmd/internal/config/public.go
+++ b/cmd/internal/config/public.go
@@ -58,4 +58,16 @@ const (
 
 	KeyImageName = "compute.image.name"
 	KeyImageId   = "compute.image.id"
+
+	KeyAccountEmail            = "account.email"
+	KeyAccountCompanyName      = "account.companyname"
+	KeyAccountFirstName        = "account.firstname"
+	KeyAccountLastName         = "account.lastname"
+	KeyAccountAddress          = "account.address"
+	KeyAccountPostcode         = "account.postcode"
+	KeyAccountCity             = "account.city"
+	KeyAccountState            = "account.state"
+	KeyAccountCountry          = "account.country"
+	KeyAccountPhone            = "account.phone"
+	KeyAccountTritonCNSEnabled = "account.triton_cns_enabled"
 )

--- a/cmd/triton/cmd/account/get/public.go
+++ b/cmd/triton/cmd/account/get/public.go
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2018, Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package get
+
+import (
+	"fmt"
+
+	"github.com/joyent/triton-go/cmd/agent/account"
+	cfg "github.com/joyent/triton-go/cmd/config"
+	"github.com/joyent/triton-go/cmd/internal/command"
+	"github.com/sean-/conswriter"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Args:         cobra.NoArgs,
+		Use:          "get",
+		Short:        "Show account information",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cons := conswriter.GetTerminal()
+
+			c, err := cfg.NewTritonConfig()
+			if err != nil {
+				return err
+			}
+
+			a, err := account.NewAccountClient(c)
+			if err != nil {
+				return err
+			}
+
+			accDetails, err := a.Get()
+			if err != nil {
+				return err
+			}
+
+			cons.Write([]byte(fmt.Sprintf("id: %s", accDetails.ID)))
+			cons.Write([]byte(fmt.Sprintf("\nlogin: %s", accDetails.Login)))
+			cons.Write([]byte(fmt.Sprintf("\nemail: %s", accDetails.Email)))
+			cons.Write([]byte(fmt.Sprintf("\ncompanyName: %s", accDetails.CompanyName)))
+			cons.Write([]byte(fmt.Sprintf("\nfirstName: %s", accDetails.FirstName)))
+			cons.Write([]byte(fmt.Sprintf("\nlastName: %s", accDetails.LastName)))
+			cons.Write([]byte(fmt.Sprintf("\npostalCode: %s", accDetails.PostalCode)))
+			cons.Write([]byte(fmt.Sprintf("\ntriton_cns_enabled: %t", accDetails.TritonCNSEnabled)))
+			cons.Write([]byte(fmt.Sprintf("\naddress: %s", accDetails.Address)))
+			cons.Write([]byte(fmt.Sprintf("\ncity: %s", accDetails.City)))
+			cons.Write([]byte(fmt.Sprintf("\nstate: %s", accDetails.State)))
+			cons.Write([]byte(fmt.Sprintf("\ncountry: %s", accDetails.Country)))
+			cons.Write([]byte(fmt.Sprintf("\nphone: %s", accDetails.Phone)))
+			cons.Write([]byte(fmt.Sprintf("\nupdated: %s (%s)", accDetails.Updated.String(), cfg.FormatTime(accDetails.Updated))))
+			cons.Write([]byte(fmt.Sprintf("\ncreated: %s (%s)", accDetails.Created.String(), cfg.FormatTime(accDetails.Created))))
+
+			return nil
+		},
+	},
+
+	Setup: func(parent *command.Command) error {
+		return nil
+	},
+}

--- a/cmd/triton/cmd/account/public.go
+++ b/cmd/triton/cmd/account/public.go
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2018, Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package account
+
+import (
+	"github.com/joyent/triton-go/cmd/internal/command"
+	"github.com/joyent/triton-go/cmd/triton/cmd/account/get"
+	"github.com/joyent/triton-go/cmd/triton/cmd/account/update"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Use:   "account",
+		Short: "Get and update your Triton account",
+	},
+
+	Setup: func(parent *command.Command) error {
+		cmds := []*command.Command{
+			get.Cmd,
+			update.Cmd,
+		}
+
+		for _, cmd := range cmds {
+			cmd.Setup(cmd)
+			parent.Cobra.AddCommand(cmd.Cobra)
+		}
+
+		return nil
+	},
+}

--- a/cmd/triton/cmd/account/update/public.go
+++ b/cmd/triton/cmd/account/update/public.go
@@ -1,0 +1,207 @@
+//
+// Copyright (c) 2018, Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package update
+
+import (
+	"fmt"
+
+	"github.com/joyent/triton-go/cmd/agent/account"
+	cfg "github.com/joyent/triton-go/cmd/config"
+	"github.com/joyent/triton-go/cmd/internal/command"
+	"github.com/joyent/triton-go/cmd/internal/config"
+	"github.com/sean-/conswriter"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Args:         cobra.NoArgs,
+		Use:          "update",
+		Short:        "Update account information",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cons := conswriter.GetTerminal()
+
+			c, err := cfg.NewTritonConfig()
+			if err != nil {
+				return err
+			}
+
+			a, err := account.NewAccountClient(c)
+			if err != nil {
+				return err
+			}
+
+			accDetails, err := a.UpdateAccount()
+			if err != nil {
+				return err
+			}
+
+			cons.Write([]byte(fmt.Sprintf("id: %s", accDetails.ID)))
+			cons.Write([]byte(fmt.Sprintf("\nlogin: %s", accDetails.Login)))
+			cons.Write([]byte(fmt.Sprintf("\nemail: %s", accDetails.Email)))
+			cons.Write([]byte(fmt.Sprintf("\ncompanyName: %s", accDetails.CompanyName)))
+			cons.Write([]byte(fmt.Sprintf("\nfirstName: %s", accDetails.FirstName)))
+			cons.Write([]byte(fmt.Sprintf("\nlastName: %s", accDetails.LastName)))
+			cons.Write([]byte(fmt.Sprintf("\npostalCode: %s", accDetails.PostalCode)))
+			cons.Write([]byte(fmt.Sprintf("\ntriton_cns_enabled: %t", accDetails.TritonCNSEnabled)))
+			cons.Write([]byte(fmt.Sprintf("\naddress: %s", accDetails.Address)))
+			cons.Write([]byte(fmt.Sprintf("\ncity: %s", accDetails.City)))
+			cons.Write([]byte(fmt.Sprintf("\nstate: %s", accDetails.State)))
+			cons.Write([]byte(fmt.Sprintf("\ncountry: %s", accDetails.Country)))
+			cons.Write([]byte(fmt.Sprintf("\nphone: %s", accDetails.Phone)))
+			cons.Write([]byte(fmt.Sprintf("\nupdated: %s (%s)", accDetails.Updated.String(), cfg.FormatTime(accDetails.Updated))))
+			cons.Write([]byte(fmt.Sprintf("\ncreated: %s (%s)", accDetails.Created.String(), cfg.FormatTime(accDetails.Created))))
+
+			return nil
+		},
+	},
+
+	Setup: func(parent *command.Command) error {
+
+		{
+			const (
+				key          = config.KeyAccountEmail
+				longName     = "email"
+				defaultValue = ""
+				description  = "Email address associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountCompanyName
+				longName     = "companyName"
+				defaultValue = ""
+				description  = "Company Name associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountFirstName
+				longName     = "firstName"
+				defaultValue = ""
+				description  = "First Name associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountLastName
+				longName     = "lastName"
+				defaultValue = ""
+				description  = "Last Name associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountAddress
+				longName     = "address"
+				defaultValue = ""
+				description  = "Address associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountPostcode
+				longName     = "postalCode"
+				defaultValue = ""
+				description  = "Postal Code associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountCity
+				longName     = "city"
+				defaultValue = ""
+				description  = "City associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountState
+				longName     = "state"
+				defaultValue = ""
+				description  = "State associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountCountry
+				longName     = "country"
+				defaultValue = ""
+				description  = "Country associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountPhone
+				longName     = "phone"
+				defaultValue = ""
+				description  = "Phone Number associated with the account"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+		{
+			const (
+				key          = config.KeyAccountTritonCNSEnabled
+				longName     = "triton_cns_enabled"
+				defaultValue = ""
+				description  = "Enable or disable the Triton CNS"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+
+		return nil
+	},
+}

--- a/cmd/triton/cmd/instances/list/public.go
+++ b/cmd/triton/cmd/instances/list/public.go
@@ -9,9 +9,7 @@
 package list
 
 import (
-	"fmt"
 	"strings"
-	"time"
 
 	"github.com/joyent/triton-go/cmd/agent/compute"
 	cfg "github.com/joyent/triton-go/cmd/config"
@@ -70,7 +68,7 @@ var Cmd = &command.Command{
 
 			var numInstances uint
 			for _, instance := range instances {
-				table.Append([]string{string(instance.ID[:8]), instance.Name, a.FormatImageName(images, instance.Image), instance.State, formatInstanceFlags(instance), formatInstanceAge(instance.Created)})
+				table.Append([]string{string(instance.ID[:8]), instance.Name, a.FormatImageName(images, instance.Image), instance.State, formatInstanceFlags(instance), cfg.FormatTime(instance.Created)})
 				numInstances++
 			}
 
@@ -82,50 +80,6 @@ var Cmd = &command.Command{
 	Setup: func(parent *command.Command) error {
 		return nil
 	},
-}
-
-func formatInstanceAge(t time.Time) string {
-	d := time.Since(t)
-
-	timeSegs := make([]string, 0, 6)
-
-	years := int64(float64(d/(24*time.Hour)) / 365.25)
-	if years > 0 {
-		timeSegs = append(timeSegs, fmt.Sprintf("%2dy", years))
-	}
-
-	months := int64(float64(d/(24*time.Hour)%365) / 30.25)
-	if months > 0 {
-		timeSegs = append(timeSegs, fmt.Sprintf("%2dmo", months))
-	}
-
-	days := int64(d/(24*time.Hour)) % 365 % 7
-	if days > 0 {
-		timeSegs = append(timeSegs, fmt.Sprintf("%2dd", days))
-	}
-
-	hours := int64(d.Hours()) % 24
-	if hours > 0 {
-		timeSegs = append(timeSegs, fmt.Sprintf("%2dh", hours))
-	}
-
-	minutes := int64(d.Minutes()) % 60
-	if minutes > 0 {
-		timeSegs = append(timeSegs, fmt.Sprintf("%2dm", minutes))
-	}
-
-	seconds := int64(d.Seconds()) % 60
-	if seconds > 0 {
-		timeSegs = append(timeSegs, fmt.Sprintf("%2ds", seconds))
-	}
-
-	maxSegs := len(timeSegs)
-	if maxSegs > 3 {
-		maxSegs = 3
-	}
-	timeSegs = timeSegs[0:maxSegs]
-
-	return strings.Join(timeSegs, " ")
 }
 
 func formatInstanceFlags(instance *tc.Instance) string {

--- a/cmd/triton/cmd/root.go
+++ b/cmd/triton/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/joyent/triton-go/cmd/internal/command"
 	"github.com/joyent/triton-go/cmd/internal/config"
 	"github.com/joyent/triton-go/cmd/internal/logger"
+	"github.com/joyent/triton-go/cmd/triton/cmd/account"
 	"github.com/joyent/triton-go/cmd/triton/cmd/docs"
 	"github.com/joyent/triton-go/cmd/triton/cmd/instances"
 	"github.com/joyent/triton-go/cmd/triton/cmd/shell"
@@ -29,6 +30,7 @@ var subCommands = []*command.Command{
 	docs.Cmd,
 	shell.Cmd,
 	version.Cmd,
+	account.Cmd,
 }
 
 var rootCmd = &command.Command{


### PR DESCRIPTION
This adds GET and UPDATE for triton account command

This PR also needs to change the Account Update request to use a
POST rather than a PUT as per the API documentation. Without this,
it doesn't actually make the changes in the API