### PR TITLE
client: Not Setting Services URL on Private Install

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -60,6 +60,18 @@ type Client struct {
 	Username      string
 }
 
+func isPrivateInstall(url string) bool {
+	for _, pattern := range knownDCFormats {
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(url)
+		if len(matches) > 1 {
+			return false
+		}
+	}
+
+	return true
+}
+
 // parseDC parses out the data center commonly found in Triton URLs. Returns an
 // error if the Triton URL does not include a known data center name, in which
 // case a URL override (TRITON_TSG_URL) must be provided.
@@ -108,7 +120,7 @@ func New(tritonURL string, mantaURL string, accountName string, signers ...authe
 	// the Triton URL (if TritonURL is available). If TRITON_TSG_URL environment
 	// variable is available than override using that value instead.
 	tsgURL := triton.GetEnv("TSG_URL")
-	if tsgURL == "" && tritonURL != "" {
+	if tsgURL == "" && tritonURL != "" && !isPrivateInstall(tritonURL) {
 		currentDC, isSamsung, err := parseDC(tritonURL)
 		if err != nil {
 			return nil, pkgerrors.Wrapf(err, InvalidDCInURL)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,6 +25,7 @@ func TestNew(t *testing.T) {
 	spcTritonURL := "https://us-east-1.api.samsungcloud.io"
 	jpcServiceURL := "https://tsg.us-east-1.svc.joyent.zone"
 	spcServiceURL := "https://tsg.us-east-1.svc.samsungcloud.zone"
+	privateInstallUrl := "https://myinstall.mycompany.com"
 
 	accountName := "test.user"
 	signer, _ := auth.NewTestSigner()
@@ -48,6 +49,7 @@ func TestNew(t *testing.T) {
 		{"bad TSG", jpcTritonURL, mantaURL, BadURL, "", accountName, signer, InvalidServicesURL},
 		{"missing accountName", jpcTritonURL, mantaURL, "", jpcServiceURL, "", signer, ErrAccountName},
 		{"missing signer", jpcTritonURL, mantaURL, "", jpcServiceURL, accountName, nil, ErrDefaultAuth},
+		{"private install", privateInstallUrl, mantaURL, "", "", accountName, signer, nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Anything other than JPC / SPC will no longer try and parse the
datacenter to set the services url