### PR TITLE
support for network objects

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -329,12 +329,18 @@ func (input *CreateInstanceInput) toAPI() (map[string]interface{}, error) {
 
 	if len(input.Networks) > 0 {
 		for _, v := range input.Networks {
-			for _, n := range networks {
-				if n.IPv4UUID != v {
-					networks = append(networks, NetworkObject{
-						IPv4UUID: v,
-					})
+			if len(networks) > 0 {
+				for _, n := range networks {
+					if n.IPv4UUID != v {
+						networks = append(networks, NetworkObject{
+							IPv4UUID: v,
+						})
+					}
 				}
+			} else {
+				networks = append(networks, NetworkObject{
+					IPv4UUID: v,
+				})
 			}
 		}
 	}

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -327,21 +327,19 @@ func (input *CreateInstanceInput) toAPI() (map[string]interface{}, error) {
 		networks = append(networks, input.NetworkObjects...)
 	}
 
-	if len(input.Networks) > 0 {
-		for _, v := range input.Networks {
-			if len(networks) > 0 {
-				for _, n := range networks {
-					if n.IPv4UUID != v {
-						networks = append(networks, NetworkObject{
-							IPv4UUID: v,
-						})
-					}
-				}
-			} else {
-				networks = append(networks, NetworkObject{
-					IPv4UUID: v,
-				})
+	for _, netuuid := range input.Networks {
+		found := false
+
+		for _, net := range networks {
+			if net.IPv4UUID == netuuid {
+				found = true
 			}
+		}
+
+		if !found {
+			networks = append(networks, NetworkObject{
+				IPv4UUID: netuuid,
+			})
 		}
 	}
 

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -54,6 +54,11 @@ type InstanceVolume struct {
 	Mountpoint string `json:"mountpoint,omitempty"`
 }
 
+type NetworkObject struct {
+	IPv4_uuid string   `json:"ipv4_uuid"`
+	IPv4_ips  []string `json:"ipv4_ips"`
+}
+
 type Instance struct {
 	ID                 string                 `json:"id"`
 	Name               string                 `json:"name"`
@@ -277,6 +282,7 @@ type CreateInstanceInput struct {
 	Package         string
 	Image           string
 	Networks        []string
+	NetworkObjects  []NetworkObject
 	Affinity        []string
 	LocalityStrict  bool
 	LocalityNear    []string
@@ -314,8 +320,12 @@ func (input *CreateInstanceInput) toAPI() (map[string]interface{}, error) {
 		result["image"] = input.Image
 	}
 
-	if len(input.Networks) > 0 {
-		result["networks"] = input.Networks
+	if len(input.NetworkObjects) > 0 {
+		result["networks"] = input.NetworkObjects
+	} else {
+		if len(input.Networks) > 0 {
+			result["networks"] = input.Networks
+		}
 	}
 
 	if len(input.Volumes) > 0 {


### PR DESCRIPTION
While developing the VirtualKubelet for Triton,  I decided it would be cool  to support Static Addresses.  That means that Triton-GO needs to support cloudapi NetworkObjects.

This should address https://github.com/joyent/triton-go/issues/139.

I don't believe the Triton CLI for creating instances was ever finished so I added up to where I think it was abandoned. 



