### PR TITLE
want instances().get of deleted instances

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, Joyent, Inc. All rights reserved.
+// Copyright (c) 2019, Joyent, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -225,12 +225,12 @@ func doNotFollowRedirects(*http.Request, []*http.Request) error {
 }
 
 // DecodeError decodes a backend Triton error into a more usable Go error type
-func (c *Client) DecodeError(resp *http.Response, requestMethod string) error {
+func (c *Client) DecodeError(resp *http.Response, requestMethod string, consumeBody bool) error {
 	err := &errors.APIError{
 		StatusCode: resp.StatusCode,
 	}
 
-	if requestMethod != http.MethodHead && resp.Body != nil {
+	if requestMethod != http.MethodHead && resp.Body != nil && consumeBody {
 		errorDecoder := json.NewDecoder(resp.Body)
 		if err := errorDecoder.Decode(err); err != nil {
 			return pkgerrors.Wrapf(err, "unable to decode error response")
@@ -267,6 +267,9 @@ type RequestInput struct {
 	Query   *url.Values
 	Headers *http.Header
 	Body    interface{}
+
+	// If the response has the HTTP status code 410 (i.e., "Gone"), should we preserve the contents of the body for the caller?
+	PreserveGone bool
 }
 
 func (c *Client) ExecuteRequestURIParams(ctx context.Context, inputs RequestInput) (io.ReadCloser, error) {
@@ -330,7 +333,7 @@ func (c *Client) ExecuteRequestURIParams(ctx context.Context, inputs RequestInpu
 		return resp.Body, nil
 	}
 
-	return nil, c.DecodeError(resp, req.Method)
+	return nil, c.DecodeError(resp, req.Method, true)
 }
 
 func (c *Client) ExecuteRequest(ctx context.Context, inputs RequestInput) (io.ReadCloser, error) {
@@ -397,12 +400,14 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 		resp.StatusCode < http.StatusMultipleChoices {
 		return resp, nil
 	}
-	// GetMachine returns a HTTP 410 response for deleted instances, but the body of the response is still a valid machine object with a State value of "deleted". Return the object to the caller instead of an error.
-	if resp.StatusCode == http.StatusGone {
-		return resp, nil
+
+	// GetMachine returns a HTTP 410 response for deleted instances, but the body of the response is still a valid machine object with a State value of "deleted". Return the object to the caller as well as an error.
+	if inputs.PreserveGone && resp.StatusCode == http.StatusGone {
+		// Do not consume the response body.
+		return resp, c.DecodeError(resp, req.Method, false)
 	}
 
-	return nil, c.DecodeError(resp, req.Method)
+	return nil, c.DecodeError(resp, req.Method, true)
 }
 
 func (c *Client) ExecuteRequestStorage(ctx context.Context, inputs RequestInput) (io.ReadCloser, http.Header, error) {
@@ -472,7 +477,7 @@ func (c *Client) ExecuteRequestStorage(ctx context.Context, inputs RequestInput)
 		return resp.Body, resp.Header, nil
 	}
 
-	return nil, nil, c.DecodeError(resp, req.Method)
+	return nil, nil, c.DecodeError(resp, req.Method, true)
 }
 
 type RequestNoEncodeInput struct {
@@ -539,7 +544,7 @@ func (c *Client) ExecuteRequestNoEncode(ctx context.Context, inputs RequestNoEnc
 		return resp.Body, resp.Header, nil
 	}
 
-	return nil, nil, c.DecodeError(resp, req.Method)
+	return nil, nil, c.DecodeError(resp, req.Method, true)
 }
 
 func (c *Client) ExecuteRequestTSG(ctx context.Context, inputs RequestInput) (io.ReadCloser, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -397,6 +397,16 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 		resp.StatusCode < http.StatusMultipleChoices {
 		return resp, nil
 	}
+	// Handle Deleted Instances,  This wil return a 410 triton-go will consider this behavior not an error and return nil.
+	// If the user wants to handle deleted instances they can do so by querying the State of the instance.
+	if resp.StatusCode == http.StatusGone {
+		return resp, nil
+	}
+
+	if resp.StatusCode >= http.StatusOK &&
+		resp.StatusCode < http.StatusMultipleChoices {
+		return resp, nil
+	}
 
 	return nil, c.DecodeError(resp, req.Method)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -397,14 +397,8 @@ func (c *Client) ExecuteRequestRaw(ctx context.Context, inputs RequestInput) (*h
 		resp.StatusCode < http.StatusMultipleChoices {
 		return resp, nil
 	}
-	// Handle Deleted Instances,  This wil return a 410 triton-go will consider this behavior not an error and return nil.
-	// If the user wants to handle deleted instances they can do so by querying the State of the instance.
+	// GetMachine returns a HTTP 410 response for deleted instances, but the body of the response is still a valid machine object with a State value of "deleted". Return the object to the caller instead of an error.
 	if resp.StatusCode == http.StatusGone {
-		return resp, nil
-	}
-
-	if resp.StatusCode >= http.StatusOK &&
-		resp.StatusCode < http.StatusMultipleChoices {
 		return resp, nil
 	}
 

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, Joyent, Inc. All rights reserved.
+// Copyright (c) 2019, Joyent, Inc. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -141,44 +141,36 @@ func (c *InstancesClient) Count(ctx context.Context, input *ListInstancesInput) 
 }
 
 func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*Instance, error) {
-	var httpError error
-
 	if err := input.Validate(); err != nil {
 		return nil, pkgerrors.Wrap(err, "unable to get machine")
 	}
 
 	fullPath := path.Join("/", c.client.AccountName, "machines", input.ID)
 	reqInputs := client.RequestInput{
-		Method: http.MethodGet,
-		Path:   fullPath,
+		Method:       http.MethodGet,
+		Path:         fullPath,
+		PreserveGone: true,
 	}
-	response, err := c.client.ExecuteRequestRaw(ctx, reqInputs)
+	response, reqErr := c.client.ExecuteRequestRaw(ctx, reqInputs)
 	if response == nil {
-		return nil, pkgerrors.Wrap(err, "unable to get machine")
+		return nil, pkgerrors.Wrap(reqErr, "unable to get machine")
 	}
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	if response.StatusCode == http.StatusNotFound {
-		return nil, &errors.APIError{
-			StatusCode: response.StatusCode,
-			Code:       "ResourceNotFound",
+	if reqErr != nil {
+		reqErr = pkgerrors.Wrap(reqErr, "unable to get machine")
+
+		// If this is not a HTTP 410 Gone error, return it immediately to the caller.  Otherwise, we'll return it alongside the instance below.
+		if response.StatusCode != http.StatusGone {
+			return nil, reqErr
 		}
-	}
-	if response.StatusCode == http.StatusGone {
-		httpError = &errors.APIError{
-			StatusCode: response.StatusCode,
-			Code:       "unable to get machine",
-		}
-	}
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "unable to get machine")
 	}
 
 	var result *_Instance
 	decoder := json.NewDecoder(response.Body)
-	if err = decoder.Decode(&result); err != nil {
-		return nil, pkgerrors.Wrap(err, "unable to decode get machine response")
+	if err := decoder.Decode(&result); err != nil {
+		return nil, pkgerrors.Wrap(err, "unable to parse JSON in get machine response")
 	}
 
 	native, err := result.toNative()
@@ -186,7 +178,8 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 		return nil, pkgerrors.Wrap(err, "unable to decode get machine response")
 	}
 
-	return native, httpError
+	// To remain compatible with the existing interface, we'll return both an error and an instance object in some cases; e.g., for HTTP 410 Gone responses for deleted instances.
+	return native, reqErr
 }
 
 type ListInstancesInput struct {

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -157,7 +157,7 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
+	if response.StatusCode == http.StatusNotFound {
 		return nil, &errors.APIError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",

--- a/compute/instances.go
+++ b/compute/instances.go
@@ -141,6 +141,8 @@ func (c *InstancesClient) Count(ctx context.Context, input *ListInstancesInput) 
 }
 
 func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*Instance, error) {
+	var httpError error
+
 	if err := input.Validate(); err != nil {
 		return nil, pkgerrors.Wrap(err, "unable to get machine")
 	}
@@ -163,6 +165,12 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 			Code:       "ResourceNotFound",
 		}
 	}
+	if response.StatusCode == http.StatusGone {
+		httpError = &errors.APIError{
+			StatusCode: response.StatusCode,
+			Code:       "unable to get machine",
+		}
+	}
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "unable to get machine")
 	}
@@ -178,7 +186,7 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 		return nil, pkgerrors.Wrap(err, "unable to decode get machine response")
 	}
 
-	return native, nil
+	return native, httpError
 }
 
 type ListInstancesInput struct {


### PR DESCRIPTION
While creating the nomad-driver-triton,  one of the desired ways that we would like to handle the exiting of a task is by examining the state of Instance.State == "deleted".   

This pretty much creates the contract that if a user of triton-go wants to handle deleted instances they must query the instance state, and not depend on a http 410 that cloudapi returns along with the instance object.