### PR TITLE
added networkobject support to ADDNic

### DIFF
--- a/compute/instances.go
+++ b/compute/instances.go
@@ -947,7 +947,9 @@ type AddNICInput struct {
 	NetworkObject NetworkObject
 }
 
-// toAPI is used to build up the JSON Object to send to the API gateway.  IT also will resolve the scenario where a user provides both a NetworkObject and a Network. If both are provided, NetworkObject wins.
+// toAPI is used to build up the JSON Object to send to the API gateway.  It 
+// also will resolve the scenario where a user provides both a NetworkObject
+// and a Network. If both are provided, NetworkObject wins.
 func (input AddNICInput) toAPI() map[string]interface{} {
 	result := map[string]interface{}{}
 


### PR DESCRIPTION
I tested this with the following 4 scenarios and it appeared to work fine.

1) Provided Both NetworkObject and Network.
2) Providing only a Network.
3) Providing a NetworkObject with only a IPv4UUID.
4) Providing a NetworkObject with a IPv4UUI and IPv4IPs.
```
        nic, err := c.Instances().AddNIC(context.Background(), &compute.AddNICInput{
                InstanceID: "8358344e-299a-4fda-bc3b-d4b4c2787bde",
                NetworkObject: compute.NetworkObject{
                        IPv4UUID: "0a63f067-d721-435e-941a-724776d69c91",
                        IPv4IPs:  []string{"10.1.1.58"},
                },
                Network: "71a1abac-f003-4b51-ac63-28d37f2ef0af",
        })
```