### PR TITLE
Add build tag to ignore dummy.go from builds

### DIFF
--- a/authentication/dummy.go
+++ b/authentication/dummy.go
@@ -1,3 +1,4 @@
+// +build ignore
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
 //


### PR DESCRIPTION
👋Hello!

This PR introduces a build tag to exclude the dummy credentials from being included in built binaries using this package.

## Before

```console
$ file before
before: Mach-O 64-bit executable x86_64  
$ strings before | grep "RSA PRIVATE"
-----BEGIN RSA PRIVATE KEY-----
-----END RSA PRIVATE KEY-----
```

## After


```console
$ file after
after: Mach-O 64-bit executable x86_64
$ strings after | grep "RSA PRIVATE"
```