### PR TITLE
Fix panic when testing images without TRITON_TEST set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.8.4 (May 11 2020)
+
+- Fix panic when testing images without TRITON_TEST set [#186]
+
 ## 1.8.3 (May 6 2020)
 
 - Add support for `brand`, `flexible_disk` and `disks` for packages [#182].

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	fakeImageID = "2b683a82-a066-11e3-97ab-2faa44701c5a"
-	localImage  *compute.Image
+	localImage  compute.Image
 )
 
 func TestAccImagesList(t *testing.T) {
@@ -63,7 +63,7 @@ func TestAccImagesList(t *testing.T) {
 						return fmt.Errorf("No images returned by list images")
 					}
 
-					localImage = images.([]*compute.Image)[0]
+					localImage = *images.([]*compute.Image)[0]
 
 					if localImage.Name == "" {
 						return fmt.Errorf("Returned image should have a name")

--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ import (
 
 // Version represents main version number of the current release
 // of the Triton-go SDK.
-const Version = "1.8.3"
+const Version = "1.8.4"
 
 // Prerelease adds a pre-release marker to the version.
 //


### PR DESCRIPTION
Fix panic when testing images without TRITON_TEST set

```
--- FAIL: TestAccImagesListInput (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x13016c6]

goroutine 32 [running]:
testing.tRunner.func1.1(0x1383a80, 0x16c79a0)
	/usr/local/go/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc000147e60)
	/usr/local/go/src/testing/testing.go:943 +0x3f9
panic(0x1383a80, 0x16c79a0)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/joyent/triton-go/v2/compute_test.TestAccImagesListInput(0xc000147e60)
	/Users/pedropc/work/triton-go/compute/images_test.go:130 +0xd6
testing.tRunner(0xc000147e60, 0x14093e8)
	/usr/local/go/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1042 +0x357
FAIL	github.com/joyent/triton-go/v2/compute	0.413s
FAIL
```