### PR TITLE
Fix command `cmd/triton/triton instance get --id`

### DIFF
--- a/cmd/triton/cmd/instances/public.go
+++ b/cmd/triton/cmd/instances/public.go
@@ -59,7 +59,7 @@ var Cmd = &command.Command{
 				description  = "Instance ID"
 			)
 
-			flags := parent.Cobra.Flags()
+			flags := parent.Cobra.PersistentFlags()
 			flags.String(longName, defaultValue, description)
 			viper.BindPFlag(key, flags.Lookup(longName))
 		}

--- a/cmd/triton/cmd/root_test.go
+++ b/cmd/triton/cmd/root_test.go
@@ -122,7 +122,6 @@ func TestGetPackageByName_Cmd(t *testing.T) {
 						return fmt.Errorf("Error compiling Regexp: %v", err)
 					}
 
-					t.Logf("\n%s =>\n%s", strings.Join(cmd.Args[:], " "), out.String())
 					if !re.MatchString(out.String()) {
 						return fmt.Errorf("Unexpected command stdout:\n%s", out.String())
 					}

--- a/cmd/triton/cmd/root_test.go
+++ b/cmd/triton/cmd/root_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/joyent/triton-go/v2/testutils"
+)
+
+func TestListDataCenters_Cmd(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					cmd := exec.Command("../triton", "datacenters")
+					out := bytes.NewBuffer([]byte{})
+
+					cmd.Stdout = out
+					cmd.Stderr = os.Stderr
+					err := cmd.Run()
+					if err != nil {
+						return fmt.Errorf("%v", err)
+					}
+					re, err := regexp.Compile(`(?i)url`)
+					if err != nil {
+						return fmt.Errorf("Error compiling Regexp: %v", err)
+					}
+
+					if !re.MatchString(out.String()) {
+						return fmt.Errorf("Unexpected command stdout:\n%s", out.String())
+					}
+
+					t.Logf("\n%s =>\n%s", strings.Join(cmd.Args[:], " "), out.String())
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestListInstances_Cmd(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					cmd := exec.Command("../triton", "instances", "list")
+					out := bytes.NewBuffer([]byte{})
+
+					cmd.Stdout = out
+					cmd.Stderr = os.Stderr
+					err := cmd.Run()
+					if err != nil {
+						return fmt.Errorf("%v", err)
+					}
+					re, err := regexp.Compile(`(?i)shortid`)
+					if err != nil {
+						return fmt.Errorf("Error compiling Regexp: %v", err)
+					}
+
+					if !re.MatchString(out.String()) {
+						return fmt.Errorf("Unexpected command stdout:\n%s", out.String())
+					}
+					t.Logf("\n%s =>\n%s", strings.Join(cmd.Args[:], " "), out.String())
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestListPackages_Cmd(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					cmd := exec.Command("../triton", "package", "list", "--memory", "128")
+					out := bytes.NewBuffer([]byte{})
+
+					cmd.Stdout = out
+					cmd.Stderr = os.Stderr
+					err := cmd.Run()
+					if err != nil {
+						return fmt.Errorf("%v", err)
+					}
+					re, err := regexp.Compile(`(?i)shortid`)
+					if err != nil {
+						return fmt.Errorf("Error compiling Regexp: %v", err)
+					}
+
+					if !re.MatchString(out.String()) {
+						return fmt.Errorf("Unexpected command stdout:\n%s", out.String())
+					}
+					t.Logf("\n%s =>\n%s", strings.Join(cmd.Args[:], " "), out.String())
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestGetPackageByName_Cmd(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					cmd := exec.Command("../triton", "package", "get", "--name", "sample-128M")
+					out := bytes.NewBuffer([]byte{})
+
+					cmd.Stdout = out
+					cmd.Stderr = os.Stderr
+					err := cmd.Run()
+					if err != nil {
+						return fmt.Errorf("%v", err)
+					}
+					re, err := regexp.Compile(`(?i)shortid`)
+					if err != nil {
+						return fmt.Errorf("Error compiling Regexp: %v", err)
+					}
+
+					t.Logf("\n%s =>\n%s", strings.Join(cmd.Args[:], " "), out.String())
+					if !re.MatchString(out.String()) {
+						return fmt.Errorf("Unexpected command stdout:\n%s", out.String())
+					}
+					t.Logf("\n%s =>\n%s", strings.Join(cmd.Args[:], " "), out.String())
+					return nil
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
The following error happens when you try to get an instance by id using the command line triton wrapper:

```
cmd/triton/triton instance get --id be94b42b
Error: unknown flag: --id
2020-05-14T19:48:30.445428000+02:00 |ERRO| unable to run error="unknown flag: --id"
```

