### PR TITLE
TRITON-2152 Add support for AccessKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ fields from `map[string][string]` and optionally `map[string]interface{}` to
 types of Metadata and Tags as defined by Triton's VMAPI: valid strings,
 booleans or numeric JSON values.
 
+- TRITON-2152 Added support for `account.AccessKeys`
+
 ## 1.8.4 (May 11 2020)
 
 - Fix panic when testing images without TRITON_TEST set [#186]

--- a/account/accesskeys.go
+++ b/account/accesskeys.go
@@ -1,0 +1,156 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package account
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path"
+	"time"
+
+	"github.com/joyent/triton-go/v2/client"
+	"github.com/pkg/errors"
+)
+
+// AccessKeysClient holds a pointer to triton client
+type AccessKeysClient struct {
+	client *client.Client
+}
+
+// AccessKey represents an access key
+type AccessKey struct {
+	// AccessKeyId id of the key
+	AccessKeyID string `json:"accesskeyid"`
+
+	// SecretAccessKey the secret used for signing requests
+	SecretAccessKey string `json:"accesskeysecret"`
+
+	// CreateDate
+	CreateDate time.Time `json:"created"`
+
+	// Status either "Active" or "Inactive"
+	Status string `json:"status"`
+
+	// UserName the uuid of the user the access key is associated with
+	UserName string
+}
+
+// ListAccessKeysInput empty struct payload for ListAccessKeys
+type ListAccessKeysInput struct{}
+
+// ListAccessKeys lists all access keys we have on record for the specified
+// account/user.
+func (c *AccessKeysClient) ListAccessKeys(ctx context.Context, _ *ListAccessKeysInput) ([]*AccessKey, error) {
+	fullPath := path.Join("/", c.client.AccountName, "accesskeys")
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   fullPath,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list accesskeys")
+	}
+
+	var result []*AccessKey
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errors.Wrap(err, "unable to decode list accesskeys response")
+	}
+	for _, elm := range result {
+		elm.UserName = c.client.AccountName
+	}
+	return result, nil
+}
+
+// GetAccessKeyInput payload for GetAccessKey
+type GetAccessKeyInput struct {
+	AccessKeyID string
+}
+
+// GetAccessKey returns an access key with the provided AccessKeyID
+func (c *AccessKeysClient) GetAccessKey(ctx context.Context, input *GetAccessKeyInput) (*AccessKey, error) {
+	fullPath := path.Join("/", c.client.AccountName, "accesskeys", input.AccessKeyID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodGet,
+		Path:   fullPath,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get key")
+	}
+
+	var result *AccessKey
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errors.Wrap(err, "unable to decode get key response")
+	}
+	result.UserName = c.client.AccountName
+
+	return result, nil
+}
+
+// DeleteAccessKeyInput payload for DeleteAccessKey
+type DeleteAccessKeyInput struct {
+	AccessKeyID string
+}
+
+// DeleteAccessKey with the provided AccessKeyID
+func (c *AccessKeysClient) DeleteAccessKey(ctx context.Context, input *DeleteAccessKeyInput) error {
+	fullPath := path.Join("/", c.client.AccountName, "accesskeys", input.AccessKeyID)
+	reqInputs := client.RequestInput{
+		Method: http.MethodDelete,
+		Path:   fullPath,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return errors.Wrap(err, "unable to delete key")
+	}
+
+	return nil
+}
+
+// CreateAccessKeyInput is the empty payload used when creating a new access key.
+type CreateAccessKeyInput struct{}
+
+// CreateAccessKey generates a new AccessKey with a new secret
+func (c *AccessKeysClient) CreateAccessKey(ctx context.Context, input *CreateAccessKeyInput) (*AccessKey, error) {
+	fullPath := path.Join("/", c.client.AccountName, "accesskeys")
+	reqInputs := client.RequestInput{
+		Method: http.MethodPost,
+		Path:   fullPath,
+		Body:   input,
+	}
+	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
+	if respReader != nil {
+		defer respReader.Close()
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create access key")
+	}
+
+	var result *AccessKey
+	decoder := json.NewDecoder(respReader)
+	if err = decoder.Decode(&result); err != nil {
+		return nil, errors.Wrap(err, "unable to decode create access key response")
+	}
+
+	result.UserName = c.client.AccountName
+
+	return result, nil
+}

--- a/account/accesskeys_test.go
+++ b/account/accesskeys_test.go
@@ -1,0 +1,222 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package account_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	triton "github.com/joyent/triton-go/v2"
+	"github.com/joyent/triton-go/v2/account"
+	"github.com/joyent/triton-go/v2/testutils"
+)
+
+// Placeholder for the generated AccessKey.AccessKeyID
+var accessKeyId = ""
+var accessKey *account.AccessKey
+
+func TestAccAccessKey_Create(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+
+			&testutils.StepClient{
+				StateBagKey: "accesskey",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return account.NewClient(config)
+				},
+			},
+
+			&testutils.StepAPICall{
+				StateBagKey: "accesskey",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.CreateAccessKeyInput{}
+					created, err := c.AccessKeys().CreateAccessKey(ctx, input)
+					if err != nil {
+						return nil, err
+					}
+					fmt.Printf("[DEBUG] Created access key %+v\n", created)
+					accessKeyId = created.AccessKeyID
+					return created, nil
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.DeleteAccessKeyInput{
+						AccessKeyID: accessKeyId,
+					}
+					c.AccessKeys().DeleteAccessKey(ctx, input)
+				},
+			},
+			&testutils.StepAssertFunc{
+				AssertFunc: func(state testutils.TritonStateBag) error {
+					accessKey := state.Get("accesskey").(*account.AccessKey)
+					if accessKey.AccessKeyID == "" {
+						t.Fatalf("Expected to have some AccessKeyID value, have: \"%v\"", accessKey.AccessKeyID)
+					}
+
+					if accessKey.SecretAccessKey == "" {
+						t.Fatalf("Expected to have some SecretAccessKey value, have: \"%v\"", accessKey.SecretAccessKey)
+					}
+
+					if accessKey.CreateDate.IsZero() {
+						t.Fatalf("Expected access key CreatedDate to be non zero time, got: \"%v\"", accessKey.CreateDate)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccAccessKey_GetAndList(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+
+			&testutils.StepClient{
+				StateBagKey: "accesskey",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return account.NewClient(config)
+				},
+			},
+
+			&testutils.StepAPICall{
+				StateBagKey: "accesskey",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.CreateAccessKeyInput{}
+					created, err := c.AccessKeys().CreateAccessKey(ctx, input)
+					if err != nil {
+						return nil, err
+					}
+					fmt.Printf("[DEBUG] Created access key %+v\n", created)
+					accessKeyId = created.AccessKeyID
+					return created, nil
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.DeleteAccessKeyInput{
+						AccessKeyID: accessKeyId,
+					}
+					c.AccessKeys().DeleteAccessKey(ctx, input)
+				},
+			},
+
+			&testutils.StepAPICall{
+				StateBagKey: "getAccessKey",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.GetAccessKeyInput{
+						AccessKeyID: accessKeyId,
+					}
+					retrieved, err := c.AccessKeys().GetAccessKey(ctx, input)
+					if err != nil {
+						return nil, err
+					}
+					if retrieved.AccessKeyID != accessKeyId {
+						t.Fatalf("Expected to retrieve a key with AccessKeyID \"%s\", but got \"%s\"", retrieved.AccessKeyID, accessKeyId)
+					}
+					return retrieved, nil
+				},
+			},
+
+			&testutils.StepAPICall{
+				StateBagKey: "listAccessKeys",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.ListAccessKeysInput{}
+					listed, err := c.AccessKeys().ListAccessKeys(ctx, input)
+					if err != nil {
+						return nil, err
+					}
+					if len(listed) == 0 {
+						t.Fatalf("Expected to retrieve a list of access keys, but got empty list")
+					}
+					if listed[0].AccessKeyID != accessKeyId {
+						t.Fatalf("Expected to retrieve a key with AccessKeyID \"%s\", but got \"%s\"", listed[0].AccessKeyID, accessKeyId)
+					}
+					return listed, nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccAccessKey_Delete(t *testing.T) {
+	testutils.AccTest(t, testutils.TestCase{
+		Steps: []testutils.Step{
+
+			&testutils.StepClient{
+				StateBagKey: "accesskey",
+				CallFunc: func(config *triton.ClientConfig) (interface{}, error) {
+					return account.NewClient(config)
+				},
+			},
+
+			&testutils.StepAPICall{
+				StateBagKey: "accesskey",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.CreateAccessKeyInput{}
+					created, err := c.AccessKeys().CreateAccessKey(ctx, input)
+					if err != nil {
+						return nil, err
+					}
+					fmt.Printf("[DEBUG] Created access key %+v\n", created)
+					accessKeyId = created.AccessKeyID
+					return created, nil
+				},
+				CleanupFunc: func(client interface{}, callState interface{}) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.DeleteAccessKeyInput{
+						AccessKeyID: accessKeyId,
+					}
+					c.AccessKeys().DeleteAccessKey(ctx, input)
+				},
+			},
+
+			&testutils.StepAPICall{
+				StateBagKey: "noop",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.DeleteAccessKeyInput{
+						AccessKeyID: accessKeyId,
+					}
+					return nil, c.AccessKeys().DeleteAccessKey(ctx, input)
+				},
+			},
+
+			&testutils.StepAPICall{
+				ErrorKey: "getAccessKeyError",
+				CallFunc: func(client interface{}) (interface{}, error) {
+					c := client.(*account.AccountClient)
+					ctx := context.Background()
+					input := &account.GetAccessKeyInput{
+						AccessKeyID: accessKeyId,
+					}
+					return c.AccessKeys().GetAccessKey(ctx, input)
+				},
+			},
+
+			&testutils.StepAssertTritonError{
+				ErrorKey: "getAccessKeyError",
+				Code:     "ResourceNotFound",
+			},
+		},
+	})
+}

--- a/account/client.go
+++ b/account/client.go
@@ -41,7 +41,7 @@ func NewClient(config *triton.ClientConfig) (*AccountClient, error) {
 	return newAccountClient(client), nil
 }
 
-// SetHeaders allows a consumer of the current client to set custom headers for
+// SetHeader allows a consumer of the current client to set custom headers for
 // the next backend HTTP request sent to CloudAPI
 func (c *AccountClient) SetHeader(header *http.Header) {
 	c.Client.RequestHeader = header
@@ -57,4 +57,10 @@ func (c *AccountClient) Config() *ConfigClient {
 // key functionality in the Triton API.
 func (c *AccountClient) Keys() *KeysClient {
 	return &KeysClient{c.Client}
+}
+
+// AccessKeys returns a Compute Client used for accessing functions related to
+// Access Keys functionality
+func (c *AccountClient) AccessKeys() *AccessKeysClient {
+	return &AccessKeysClient{c.Client}
 }


### PR DESCRIPTION
Tests passing so far:

```
triton-go(TRITON-2152) pedropc$ go test -v ./account/accesskeys_test.go
=== RUN   TestAccAccessKey_Create
[DEBUG] Created access key &{AccessKeyID:f3e8c7d987e333d8d84d8868c66dac2d SecretAccessKey:6f397999e5747d4fa0f817a02352e2cb9d517cd15a63caea70358fbd076c1e4b CreateDate:2020-07-30 15:39:34.029 +0000 UTC Status:Active UserName:account}
--- PASS: TestAccAccessKey_Create (0.37s)
=== RUN   TestAccAccessKey_GetAndList
[DEBUG] Created access key &{AccessKeyID:43d5da8698a86857b7f9783832985066 SecretAccessKey:76e719310ad1ce9beeb503349c2ef92f98711f064d980b2e65e59a8b078229a9 CreateDate:2020-07-30 15:39:34.378 +0000 UTC Status:Active UserName:account}
--- PASS: TestAccAccessKey_GetAndList (0.42s)
=== RUN   TestAccAccessKey_Delete
[DEBUG] Created access key &{AccessKeyID:f23e1b5b05fe7aa3d3fa614cea81ae59 SecretAccessKey:1cf203f6b6abffac4ad3960d2a3da1d4b2117a79baad9362294fdb2b70c695ca CreateDate:2020-07-30 15:39:34.802 +0000 UTC Status:Active UserName:account}
--- PASS: TestAccAccessKey_Delete (0.48s)
PASS
ok  	command-line-arguments	1.533s
```

