### PR TITLE
TRITON-2152 Added `triton accesskeys create|get|list|delete` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## 2.0.0-pre3 (July 31 2020)
+
+- TRITON-2152 Added `triton accesskeys create|get|list|delete` subcommands
+
+## 2.0.0-pre2 (July 30 2020)
+
+- TRITON-2152 Added support for `account.AccessKeys`
+
 ## 2.0.0-pre1 (May 11 2020)
 
 **NOTE:** This is a precursor release of triton v2.0.0, including backwards
@@ -8,8 +16,6 @@ fields from `map[string][string]` and optionally `map[string]interface{}` to
 `map[string]interface{}` everywhere. This change suits better with the possible
 types of Metadata and Tags as defined by Triton's VMAPI: valid strings,
 booleans or numeric JSON values.
-
-- TRITON-2152 Added support for `account.AccessKeys`
 
 ## 1.8.4 (May 11 2020)
 

--- a/cmd/agent/account/public.go
+++ b/cmd/agent/account/public.go
@@ -208,3 +208,64 @@ func (c *AgentAccountClient) GetKey() (*tac.Key, error) {
 
 	return nil, nil
 }
+
+func (c *AgentAccountClient) ListAccessKeys() ([]*tac.AccessKey, error) {
+	accesskeys, err := c.client.AccessKeys().ListAccessKeys(context.Background(), &tac.ListAccessKeysInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	return accesskeys, nil
+}
+
+func (c *AgentAccountClient) CreateAccessKey() (*tac.AccessKey, error) {
+	params := &tac.CreateAccessKeyInput{}
+
+	accesskey, err := c.client.AccessKeys().CreateAccessKey(context.Background(), params)
+	if err != nil {
+		return nil, err
+	}
+
+	return accesskey, nil
+}
+
+func (c *AgentAccountClient) DeleteAccessKey() (*tac.AccessKey, error) {
+	var accesskey *tac.AccessKey
+
+	accesskeyid := config.GetAccessKeyID()
+	if accesskeyid != "" {
+		k, err := c.client.AccessKeys().GetAccessKey(context.Background(), &tac.GetAccessKeyInput{
+			AccessKeyID: accesskeyid,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		accesskey = k
+	}
+
+	err := c.client.AccessKeys().DeleteAccessKey(context.Background(), &tac.DeleteAccessKeyInput{
+		AccessKeyID: accesskeyid,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return accesskey, nil
+}
+
+func (c *AgentAccountClient) GetAccessKey() (*tac.AccessKey, error) {
+	accesskeyid := config.GetAccessKeyID()
+	if accesskeyid != "" {
+		accesskey, err := c.client.AccessKeys().GetAccessKey(context.Background(), &tac.GetAccessKeyInput{
+			AccessKeyID: accesskeyid,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return accesskey, nil
+	}
+
+	return nil, nil
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -426,6 +426,10 @@ func GetSSHKey() string {
 	return viper.GetString(config.KeySSHKey)
 }
 
+func GetAccessKeyID() string {
+	return viper.GetString(config.KeyAccessKeyID)
+}
+
 func IsBlockingAction() bool {
 	return viper.GetBool(config.KeyInstanceWait)
 }

--- a/cmd/internal/config/public.go
+++ b/cmd/internal/config/public.go
@@ -67,6 +67,8 @@ const (
 	KeySSHKeyName        = "keys.name"
 	KeySSHKey            = "keys.publickey"
 
+	KeyAccessKeyID = "accesskeys.accesskeyid"
+
 	KeyAccountEmail            = "account.email"
 	KeyAccountCompanyName      = "account.companyname"
 	KeyAccountFirstName        = "account.firstname"

--- a/cmd/triton/cmd/accesskeys/create/public.go
+++ b/cmd/triton/cmd/accesskeys/create/public.go
@@ -1,0 +1,73 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package create
+
+import (
+	"fmt"
+
+	"github.com/joyent/triton-go/v2/cmd/agent/account"
+	cfg "github.com/joyent/triton-go/v2/cmd/config"
+	"github.com/joyent/triton-go/v2/cmd/internal/command"
+	"github.com/joyent/triton-go/v2/cmd/internal/config"
+	"github.com/sean-/conswriter"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Args:         cobra.NoArgs,
+		Use:          "create",
+		Aliases:      []string{"add"},
+		Short:        "create Triton Access Key",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cons := conswriter.GetTerminal()
+
+			c, err := cfg.NewTritonConfig()
+			if err != nil {
+				return err
+			}
+
+			a, err := account.NewAccountClient(c)
+			if err != nil {
+				return err
+			}
+
+			accesskey, err := a.CreateAccessKey()
+			if err != nil {
+				return err
+			}
+
+			cons.Write([]byte(fmt.Sprintf("Created access key %q", accesskey.AccessKeyID)))
+
+			return nil
+		},
+	},
+	Setup: func(parent *command.Command) error {
+
+		{
+			const (
+				key          = config.KeyAccessKeyID
+				longName     = "accesskeyid"
+				defaultValue = ""
+				description  = "Access Key Identifier"
+			)
+
+			flags := parent.Cobra.Flags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+
+		return nil
+	},
+}

--- a/cmd/triton/cmd/accesskeys/delete/public.go
+++ b/cmd/triton/cmd/accesskeys/delete/public.go
@@ -1,0 +1,61 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package accesskeydelete
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/joyent/triton-go/v2/cmd/agent/account"
+	cfg "github.com/joyent/triton-go/v2/cmd/config"
+	"github.com/joyent/triton-go/v2/cmd/internal/command"
+	"github.com/sean-/conswriter"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Args:         cobra.NoArgs,
+		Use:          "delete",
+		Short:        "delete Triton Access Key",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cfg.GetAccessKeyID() == "" {
+				return errors.New("`accesskeyid` must be specified")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cons := conswriter.GetTerminal()
+
+			c, err := cfg.NewTritonConfig()
+			if err != nil {
+				return err
+			}
+
+			a, err := account.NewAccountClient(c)
+			if err != nil {
+				return err
+			}
+
+			accesskey, err := a.DeleteAccessKey()
+			if err != nil {
+				return err
+			}
+
+			cons.Write([]byte(fmt.Sprintf("Deleted access key %q", accesskey.AccessKeyID)))
+
+			return nil
+		},
+	},
+	Setup: func(parent *command.Command) error {
+		return nil
+	},
+}

--- a/cmd/triton/cmd/accesskeys/get/public.go
+++ b/cmd/triton/cmd/accesskeys/get/public.go
@@ -1,0 +1,59 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package get
+
+import (
+	"errors"
+
+	"github.com/joyent/triton-go/v2/cmd/agent/account"
+	cfg "github.com/joyent/triton-go/v2/cmd/config"
+	"github.com/joyent/triton-go/v2/cmd/internal/command"
+	"github.com/sean-/conswriter"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Args:         cobra.NoArgs,
+		Use:          "get",
+		Short:        "get Triton Access Key",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cfg.GetAccessKeyID() == "" {
+				return errors.New("`accesskeyid` must be specified")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cons := conswriter.GetTerminal()
+
+			c, err := cfg.NewTritonConfig()
+			if err != nil {
+				return err
+			}
+
+			a, err := account.NewAccountClient(c)
+			if err != nil {
+				return err
+			}
+
+			accesskey, err := a.GetAccessKey()
+			if err != nil {
+				return err
+			}
+			cons.Write([]byte(accesskey.SecretAccessKey))
+
+			return nil
+		},
+	},
+	Setup: func(parent *command.Command) error {
+		return nil
+	},
+}

--- a/cmd/triton/cmd/accesskeys/list/public.go
+++ b/cmd/triton/cmd/accesskeys/list/public.go
@@ -1,0 +1,73 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package list
+
+import (
+	"github.com/joyent/triton-go/v2/cmd/agent/account"
+	cfg "github.com/joyent/triton-go/v2/cmd/config"
+	"github.com/joyent/triton-go/v2/cmd/internal/command"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sean-/conswriter"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Args:         cobra.NoArgs,
+		Use:          "list",
+		Short:        "list Triton Access Keys",
+		Aliases:      []string{"ls"},
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cons := conswriter.GetTerminal()
+
+			c, err := cfg.NewTritonConfig()
+			if err != nil {
+				return err
+			}
+
+			a, err := account.NewAccountClient(c)
+			if err != nil {
+				return err
+			}
+
+			accesskeys, err := a.ListAccessKeys()
+			if err != nil {
+				return err
+			}
+
+			table := tablewriter.NewWriter(cons)
+			table.SetHeaderAlignment(tablewriter.ALIGN_CENTER)
+			table.SetHeaderLine(false)
+			table.SetAutoFormatHeaders(true)
+
+			table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT})
+			table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+			table.SetCenterSeparator("")
+			table.SetColumnSeparator("")
+			table.SetRowSeparator("")
+
+			table.SetHeader([]string{"ID", "SECRET"})
+
+			for _, accesskey := range accesskeys {
+				table.Append([]string{accesskey.AccessKeyID, accesskey.SecretAccessKey})
+			}
+
+			table.Render()
+
+			return nil
+		},
+	},
+	Setup: func(parent *command.Command) error {
+		return nil
+	},
+}

--- a/cmd/triton/cmd/accesskeys/public.go
+++ b/cmd/triton/cmd/accesskeys/public.go
@@ -1,0 +1,58 @@
+//
+// Copyright 2020 Joyent, Inc. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package accesskeys
+
+import (
+	"github.com/joyent/triton-go/v2/cmd/internal/command"
+	"github.com/joyent/triton-go/v2/cmd/internal/config"
+	"github.com/joyent/triton-go/v2/cmd/triton/cmd/accesskeys/create"
+	accessKeyDelete "github.com/joyent/triton-go/v2/cmd/triton/cmd/accesskeys/delete"
+	"github.com/joyent/triton-go/v2/cmd/triton/cmd/accesskeys/get"
+	"github.com/joyent/triton-go/v2/cmd/triton/cmd/accesskeys/list"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var Cmd = &command.Command{
+	Cobra: &cobra.Command{
+		Use:     "accesskeys",
+		Aliases: []string{"accesskey"},
+		Short:   "List and manage Triton Access Keys.",
+	},
+
+	Setup: func(parent *command.Command) error {
+
+		cmds := []*command.Command{
+			list.Cmd,
+			get.Cmd,
+			accessKeyDelete.Cmd,
+			create.Cmd,
+		}
+
+		for _, cmd := range cmds {
+			cmd.Setup(cmd)
+			parent.Cobra.AddCommand(cmd.Cobra)
+		}
+
+		{
+			const (
+				key          = config.KeyAccessKeyID
+				longName     = "accesskeyid"
+				defaultValue = ""
+				description  = "Access Key Identifier"
+			)
+
+			flags := parent.Cobra.PersistentFlags()
+			flags.String(longName, defaultValue, description)
+			viper.BindPFlag(key, flags.Lookup(longName))
+		}
+
+		return nil
+	},
+}

--- a/cmd/triton/cmd/root.go
+++ b/cmd/triton/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/joyent/triton-go/v2/cmd/internal/command"
 	"github.com/joyent/triton-go/v2/cmd/internal/config"
 	"github.com/joyent/triton-go/v2/cmd/internal/logger"
+	"github.com/joyent/triton-go/v2/cmd/triton/cmd/accesskeys"
 	"github.com/joyent/triton-go/v2/cmd/triton/cmd/account"
 	"github.com/joyent/triton-go/v2/cmd/triton/cmd/datacenters"
 	"github.com/joyent/triton-go/v2/cmd/triton/cmd/docs"
@@ -39,6 +40,7 @@ var subCommands = []*command.Command{
 	services.Cmd,
 	packages.Cmd,
 	keys.Cmd,
+	accesskeys.Cmd,
 }
 
 var rootCmd = &command.Command{

--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ import (
 
 // Version represents main version number of the current release
 // of the Triton-go SDK.
-const Version = "2.0.0-pre1"
+const Version = "2.0.0-pre3"
 
 // Prerelease adds a pre-release marker to the version.
 //


### PR DESCRIPTION
```
thanagar: triton-go(master) pedropc$ ./cmd/triton/triton accesskeys list
 ID  SECRET
thanagar: triton-go(master) pedropc$ ./cmd/triton/triton accesskeys create
Created access key "9bca5e6ff274bb367eda605c863c3893"
thanagar: triton-go(master) pedropc$ ./cmd/triton/triton accesskeys list
                ID                                              SECRET
 9bca5e6ff274bb367eda605c863c3893  b34a740fec8115f3b1e47a4a0b0f740c38f32d9821dba7d21d18b46663fb1f2a
thanagar: triton-go(master) pedropc$ ./cmd/triton/triton accesskeys get --accesskeyid 9bca5e6ff274bb367eda605c863c3893
b34a740fec8115f3b1e47a4a0b0f740c38f32d9821dba7d21d18b46663fb1f2a
thanagar: triton-go(master) pedropc$ ./cmd/triton/triton accesskeys delete --accesskeyid 9bca5e6ff274bb367eda605c863c3893
Deleted access key "9bca5e6ff274bb367eda605c863c3893"
thanagar: triton-go(master) pedropc$ ./cmd/triton/triton accesskeys list
 ID  SECRET
```