### PR TITLE
examples/compute/create_instance_with_volumes: fix unit tests

### DIFF
--- a/examples/compute/create_instance_with_volumes/main.go
+++ b/examples/compute/create_instance_with_volumes/main.go
@@ -180,6 +180,8 @@ func main() {
 
 	// Create a new instance using our input attributes...
 	// https://github.com/TritonDataCenter/triton-go/v2/blob/master/compute/instances.go#L206
+	tagsInput := make(map[string]interface{}, 1)
+	tagsInput["tag1"] = "value1"
 	createInput := &compute.CreateInstanceInput{
 		Name:     testutils.RandString(10),
 		Package:  PackageName,
@@ -188,9 +190,7 @@ func main() {
 		Volumes: []compute.InstanceVolume{
 			instanceVolume,
 		},
-		Tags: map[string]string{
-			"tag1": "value1",
-		},
+		Tags: tagsInput,
 	}
 
 	created, err := c.Instances().Create(context.Background(), createInput)


### PR DESCRIPTION
The unit tests for this project are currently failing because of the following:

`examples/compute/create_instance_with_volumes/main.go:191:9: cannot use map[string]string{…} (value of type
 map[string]string) as map[string]interface{} value in struct literal`

This fixes the example code and brings the unit tests back to passing.