### PR TITLE
TRITON-2542 Add support for ed25519 keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+#
+# Copyright 2026 Edgecast Cloud LLC.
+#
+
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+## 2.0.0-pre5 (April 13 2026)
+
+- TRITON-2542 Add support for ed25519 keys
+- Fix UpdateConfig endpoint support
+- Fix issue decoding image tags with non boolean keys
+- Fix ForceDelete behavior in `deleteAll` [#155]
+- Fix dropped marshal errors [#204]
+- Fix create_instance_with_volumes unit test [#205]
+
 ## 2.0.0-pre4 (May 23 2025)
 
 - Added delegate_dataset support to instance creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 2.0.0-pre5 (April 13 2026)
 
+**NOTE:** The `deleteAll` helper was fundamentally broken — when
+`ForceDelete` was set to `true`, it failed to actually remove all child
+entries before deleting the parent directory. This is now fixed.
+
+- Fix ForceDelete behavior in `deleteAll` [#155]
 - TRITON-2542 Add support for ed25519 keys
 - Fix UpdateConfig endpoint support
 - Fix issue decoding image tags with non boolean keys
-- Fix ForceDelete behavior in `deleteAll` [#155]
 - Fix dropped marshal errors [#204]
 - Fix create_instance_with_volumes unit test [#205]
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 #
 # Copyright 2020 Joyent, Inc.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 TEST?=$$(go list ./... |grep -Ev 'vendor|examples|testutils')
@@ -14,18 +15,13 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 .PHONY: all
 all:
 
-.PHONY: tools
-tools: ## Download and install all dev/code tools
-	@echo "==> Installing dev tools"
-	go get -u github.com/golang/dep/cmd/dep
-
 .PHONY: build
-build:
-	@govvv build
+build: ## Build all packages
+	@go build ./...
 
 .PHONY: install
-install:
-	@govvv install
+install: ## Install all packages
+	@go install ./...
 
 .PHONY: test
 test: ## Run unit tests
@@ -38,8 +34,9 @@ testacc: ## Run acceptance tests
 	TRITON_TEST=1 go test $(TEST) -v -run TestAcc -timeout 60m
 
 .PHONY: check
-check:
-	scripts/gofmt-check.sh
+check: ## Run all lint checks (gofmt, vet)
+	@scripts/gofmt-check.sh
+	@go vet ./...
 
 .PHONY: help
 help: ## Display this help message

--- a/account/config.go
+++ b/account/config.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/account/config.go
+++ b/account/config.go
@@ -64,7 +64,7 @@ type UpdateConfigInput struct {
 func (c *ConfigClient) Update(ctx context.Context, input *UpdateConfigInput) (*Config, error) {
 	fullPath := path.Join("/", c.client.AccountName, "config")
 	reqInputs := client.RequestInput{
-		Method: http.MethodPost,
+		Method: http.MethodPut,
 		Path:   fullPath,
 		Body:   input,
 	}

--- a/account/config_test.go
+++ b/account/config_test.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/account/config_test.go
+++ b/account/config_test.go
@@ -141,7 +141,7 @@ func TestUpdateConfig(t *testing.T) {
 	}
 
 	t.Run("successful", func(t *testing.T) {
-		testutils.RegisterResponder("POST", path.Join("/", accountUrl, "config"), updateConfigSuccess)
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "config"), updateConfigSuccess)
 
 		_, err := do(context.Background(), accountClient)
 		if err != nil {
@@ -150,7 +150,7 @@ func TestUpdateConfig(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		testutils.RegisterResponder("POST", path.Join("/", accountUrl, "config"), updateConfigError)
+		testutils.RegisterResponder("PUT", path.Join("/", accountUrl, "config"), updateConfigError)
 
 		_, err := do(context.Background(), accountClient)
 		if err == nil {

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -1,0 +1,535 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+//
+// Copyright 2025 Edgecast Cloud LLC.
+//
+
+package authentication
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// helper: generate an ed25519 private key and return the raw key, its PEM
+// encoding, and the colon-separated MD5 fingerprint suitable for use as a
+// KeyID.
+func generateEd25519Key(t *testing.T) (ed25519.PrivateKey, []byte, string) {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
+
+	fingerprint := computeFingerprint(t, priv.Public())
+
+	return priv, pemBytes, fingerprint
+}
+
+// helper: generate an RSA private key and return the raw key, its PEM
+// encoding, and the colon-separated MD5 fingerprint.
+func generateRSAKey(t *testing.T) (*rsa.PrivateKey, []byte, string) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+
+	fingerprint := computeFingerprint(t, priv.Public())
+
+	return priv, pemBytes, fingerprint
+}
+
+// helper: generate an ECDSA private key and return the raw key, its PEM
+// encoding, and the colon-separated MD5 fingerprint.
+func generateECDSAKey(t *testing.T) (*ecdsa.PrivateKey, []byte, string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
+
+	fingerprint := computeFingerprint(t, priv.Public())
+
+	return priv, pemBytes, fingerprint
+}
+
+// computeFingerprint returns the colon-separated MD5 fingerprint of a
+// crypto.PublicKey, matching the format expected by NewPrivateKeySigner.
+func computeFingerprint(t *testing.T, pub crypto.PublicKey) string {
+	t.Helper()
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("ssh.NewPublicKey: %v", err)
+	}
+
+	hash := md5.New()
+	hash.Write(sshPub.Marshal())
+	hex := fmt.Sprintf("%x", hash.Sum(nil))
+
+	var parts []string
+	for i := 0; i < len(hex); i += 2 {
+		parts = append(parts, hex[i:i+2])
+	}
+
+	return strings.Join(parts, ":")
+}
+
+// ---------------------------------------------------------------------------
+// Test Group 1: ed25519 signature type
+// ---------------------------------------------------------------------------
+
+func TestEd25519Signature(t *testing.T) {
+	blob := make([]byte, ed25519.SignatureSize)
+	for i := range blob {
+		blob[i] = byte(i)
+	}
+
+	sig, err := newEd25519Signature(blob)
+	if err != nil {
+		t.Fatalf("newEd25519Signature: %v", err)
+	}
+
+	if sig.SignatureType() != ED25519_SHA512 {
+		t.Errorf("SignatureType() = %q, want %q", sig.SignatureType(), ED25519_SHA512)
+	}
+
+	expected := base64.StdEncoding.EncodeToString(blob)
+	if sig.String() != expected {
+		t.Errorf("String() = %q, want %q", sig.String(), expected)
+	}
+}
+
+func TestEd25519SignatureValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		blob []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"too short", make([]byte, 32)},
+		{"too long", make([]byte, 128)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newEd25519Signature(tc.blob)
+			if err == nil {
+				t.Error("expected error for invalid signature length, got nil")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test Group 2: keyFormatToKeyType
+// ---------------------------------------------------------------------------
+
+func TestKeyFormatToKeyType(t *testing.T) {
+	tests := []struct {
+		format  string
+		want    string
+		wantErr bool
+	}{
+		{"ssh-rsa", "rsa", false},
+		{"ssh-ed25519", "ed25519", false},
+		{"ecdsa-sha2-nistp256", "ecdsa", false},
+		{"ecdsa-sha2-nistp384", "ecdsa", false},
+		{"ecdsa-sha2-nistp521", "ecdsa", false},
+		{"ssh-dss", "", true},
+		{"unknown", "", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.format, func(t *testing.T) {
+			got, err := keyFormatToKeyType(tc.format)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for format %q, got nil", tc.format)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("keyFormatToKeyType(%q) = %q, want %q", tc.format, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test Group 3: formatPublicKeyFingerprint
+// ---------------------------------------------------------------------------
+
+func TestFormatPublicKeyFingerprint(t *testing.T) {
+	rsaKey, _, rsaFP := generateRSAKey(t)
+	edKey, _, edFP := generateEd25519Key(t)
+
+	// Test ed25519 private key (the new code path)
+	t.Run("ed25519 private key", func(t *testing.T) {
+		got, err := formatPublicKeyFingerprint(edKey, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != edFP {
+			t.Errorf("fingerprint = %q, want %q", got, edFP)
+		}
+	})
+
+	// Test ed25519 raw hex (display=false)
+	t.Run("ed25519 raw hex", func(t *testing.T) {
+		got, err := formatPublicKeyFingerprint(edKey, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := strings.Replace(edFP, ":", "", -1)
+		if got != expected {
+			t.Errorf("raw fingerprint = %q, want %q", got, expected)
+		}
+	})
+
+	// Test RSA private key
+	t.Run("rsa private key", func(t *testing.T) {
+		got, err := formatPublicKeyFingerprint(rsaKey, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != rsaFP {
+			t.Errorf("fingerprint = %q, want %q", got, rsaFP)
+		}
+	})
+
+	// Test ecdsa private key
+	t.Run("ecdsa private key", func(t *testing.T) {
+		ecKey, _, ecFP := generateECDSAKey(t)
+		got, err := formatPublicKeyFingerprint(ecKey, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ecFP {
+			t.Errorf("fingerprint = %q, want %q", got, ecFP)
+		}
+	})
+
+	// Test ssh.PublicKey directly (the new case added in this branch)
+	t.Run("ssh.PublicKey", func(t *testing.T) {
+		sshPub, err := ssh.NewPublicKey(edKey.Public())
+		if err != nil {
+			t.Fatalf("ssh.NewPublicKey: %v", err)
+		}
+		got, err := formatPublicKeyFingerprint(sshPub, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != edFP {
+			t.Errorf("fingerprint = %q, want %q", got, edFP)
+		}
+	})
+
+	// Test unsupported type
+	t.Run("unsupported type", func(t *testing.T) {
+		_, err := formatPublicKeyFingerprint("not a key", false)
+		if err == nil {
+			t.Error("expected error for unsupported type, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test Group 4: PrivateKeySigner
+// ---------------------------------------------------------------------------
+
+func TestPrivateKeySignerEd25519(t *testing.T) {
+	_, pemBytes, fingerprint := generateEd25519Key(t)
+
+	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
+		KeyID:              fingerprint,
+		PrivateKeyMaterial: pemBytes,
+		AccountName:        "testaccount",
+		Username:           "testuser",
+	})
+	if err != nil {
+		t.Fatalf("NewPrivateKeySigner: %v", err)
+	}
+
+	if signer.DefaultAlgorithm() != ED25519_SHA512 {
+		t.Errorf("DefaultAlgorithm() = %q, want %q", signer.DefaultAlgorithm(), ED25519_SHA512)
+	}
+
+	t.Run("Sign", func(t *testing.T) {
+		header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+
+		if !strings.Contains(header, "ed25519-sha512") {
+			t.Errorf("Sign output missing algorithm, got: %s", header)
+		}
+		if !strings.Contains(header, "Signature keyId=") {
+			t.Errorf("Sign output missing keyId, got: %s", header)
+		}
+		if !strings.Contains(header, "testaccount") {
+			t.Errorf("Sign output missing account name, got: %s", header)
+		}
+	})
+
+	t.Run("SignRaw", func(t *testing.T) {
+		signedBase64, algo, err := signer.SignRaw("test message")
+		if err != nil {
+			t.Fatalf("SignRaw: %v", err)
+		}
+
+		if algo != ED25519_SHA512 {
+			t.Errorf("algorithm = %q, want %q", algo, ED25519_SHA512)
+		}
+
+		// Verify the signature is valid base64
+		_, err = base64.StdEncoding.DecodeString(signedBase64)
+		if err != nil {
+			t.Fatalf("invalid base64 in signature: %v", err)
+		}
+	})
+
+	t.Run("SignRaw verify", func(t *testing.T) {
+		// Generate a fresh key so we have access to the raw private key
+		// for verification.
+		priv, pemBytes2, fp2 := generateEd25519Key(t)
+
+		signer2, err := NewPrivateKeySigner(PrivateKeySignerInput{
+			KeyID:              fp2,
+			PrivateKeyMaterial: pemBytes2,
+			AccountName:        "testaccount",
+		})
+		if err != nil {
+			t.Fatalf("NewPrivateKeySigner: %v", err)
+		}
+
+		message := "verify me"
+		signedBase64, _, err := signer2.SignRaw(message)
+		if err != nil {
+			t.Fatalf("SignRaw: %v", err)
+		}
+
+		sigBytes, err := base64.StdEncoding.DecodeString(signedBase64)
+		if err != nil {
+			t.Fatalf("base64 decode: %v", err)
+		}
+
+		pub := priv.Public().(ed25519.PublicKey)
+		if !ed25519.Verify(pub, []byte(message), sigBytes) {
+			t.Error("ed25519.Verify failed: signature is not valid")
+		}
+	})
+}
+
+func TestPrivateKeySignerRSA(t *testing.T) {
+	_, pemBytes, fingerprint := generateRSAKey(t)
+
+	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
+		KeyID:              fingerprint,
+		PrivateKeyMaterial: pemBytes,
+		AccountName:        "testaccount",
+	})
+	if err != nil {
+		t.Fatalf("NewPrivateKeySigner: %v", err)
+	}
+
+	if signer.DefaultAlgorithm() != RSA_SHA512 {
+		t.Errorf("DefaultAlgorithm() = %q, want %q", signer.DefaultAlgorithm(), RSA_SHA512)
+	}
+
+	header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !strings.Contains(header, "rsa-sha512") {
+		t.Errorf("Sign output missing algorithm, got: %s", header)
+	}
+}
+
+func TestPrivateKeySignerECDSA(t *testing.T) {
+	_, pemBytes, fingerprint := generateECDSAKey(t)
+
+	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
+		KeyID:              fingerprint,
+		PrivateKeyMaterial: pemBytes,
+		AccountName:        "testaccount",
+	})
+	if err != nil {
+		t.Fatalf("NewPrivateKeySigner: %v", err)
+	}
+
+	if signer.DefaultAlgorithm() != ECDSA_SHA512 {
+		t.Errorf("DefaultAlgorithm() = %q, want %q", signer.DefaultAlgorithm(), ECDSA_SHA512)
+	}
+
+	header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !strings.Contains(header, "ecdsa-sha512") {
+		t.Errorf("Sign output missing algorithm, got: %s", header)
+	}
+}
+
+func TestPrivateKeySignerBadFingerprint(t *testing.T) {
+	_, pemBytes, _ := generateEd25519Key(t)
+
+	_, err := NewPrivateKeySigner(PrivateKeySignerInput{
+		KeyID:              "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+		PrivateKeyMaterial: pemBytes,
+		AccountName:        "testaccount",
+	})
+	if err == nil {
+		t.Fatal("expected error for mismatched fingerprint, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestPrivateKeySignerBadKeyMaterial(t *testing.T) {
+	_, err := NewPrivateKeySigner(PrivateKeySignerInput{
+		KeyID:              "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+		PrivateKeyMaterial: []byte("not a valid key"),
+		AccountName:        "testaccount",
+	})
+	if err == nil {
+		t.Fatal("expected error for bad key material, got nil")
+	}
+}
+
+// Test that Sign() produces a consistent format by calling SignRaw() internally.
+func TestPrivateKeySignerSignConsistency(t *testing.T) {
+	_, pemBytes, fingerprint := generateEd25519Key(t)
+
+	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
+		KeyID:              fingerprint,
+		PrivateKeyMaterial: pemBytes,
+		AccountName:        "testaccount",
+		Username:           "testuser",
+	})
+	if err != nil {
+		t.Fatalf("NewPrivateKeySigner: %v", err)
+	}
+
+	// Sign should produce a properly formatted authorization header
+	header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	// Verify the header format
+	if !strings.HasPrefix(header, "Signature keyId=\"") {
+		t.Errorf("header should start with 'Signature keyId=\"', got: %s", header)
+	}
+	if !strings.Contains(header, `algorithm="ed25519-sha512"`) {
+		t.Errorf("header missing algorithm, got: %s", header)
+	}
+	if !strings.Contains(header, `headers="date"`) {
+		t.Errorf("header missing headers field, got: %s", header)
+	}
+	if !strings.Contains(header, `signature="`) {
+		t.Errorf("header missing signature field, got: %s", header)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test Group 5: KeyID generation
+// ---------------------------------------------------------------------------
+
+func TestKeyIDGenerate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  KeyID
+		expect string
+	}{
+		{
+			name: "no user",
+			input: KeyID{
+				AccountName: "myaccount",
+				Fingerprint: "aa:bb:cc",
+			},
+			expect: "/myaccount/keys/aa:bb:cc",
+		},
+		{
+			name: "with user",
+			input: KeyID{
+				AccountName: "myaccount",
+				UserName:    "myuser",
+				Fingerprint: "aa:bb:cc",
+			},
+			expect: "/myaccount/users/myuser/keys/aa:bb:cc",
+		},
+		{
+			name: "manta with user",
+			input: KeyID{
+				AccountName: "myaccount",
+				UserName:    "myuser",
+				Fingerprint: "aa:bb:cc",
+				IsManta:     true,
+			},
+			expect: "/myaccount/myuser/keys/aa:bb:cc",
+		},
+		{
+			name: "manta no user",
+			input: KeyID{
+				AccountName: "myaccount",
+				Fingerprint: "aa:bb:cc",
+				IsManta:     true,
+			},
+			expect: "/myaccount/keys/aa:bb:cc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.generate()
+			if got != tc.expect {
+				t.Errorf("generate() = %q, want %q", got, tc.expect)
+			}
+		})
+	}
+}

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -12,12 +12,9 @@ package authentication
 
 import (
 	"crypto"
-	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/md5"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -37,48 +34,6 @@ func generateEd25519Key(t *testing.T) (ed25519.PrivateKey, []byte, string) {
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey: %v", err)
-	}
-
-	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
-	if err != nil {
-		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
-	}
-
-	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
-
-	fingerprint := computeFingerprint(t, priv.Public())
-
-	return priv, pemBytes, fingerprint
-}
-
-// helper: generate an RSA private key and return the raw key, its PEM
-// encoding, and the colon-separated MD5 fingerprint.
-func generateRSAKey(t *testing.T) (*rsa.PrivateKey, []byte, string) {
-	t.Helper()
-
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("rsa.GenerateKey: %v", err)
-	}
-
-	pemBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(priv),
-	})
-
-	fingerprint := computeFingerprint(t, priv.Public())
-
-	return priv, pemBytes, fingerprint
-}
-
-// helper: generate an ECDSA private key and return the raw key, its PEM
-// encoding, and the colon-separated MD5 fingerprint.
-func generateECDSAKey(t *testing.T) (*ecdsa.PrivateKey, []byte, string) {
-	t.Helper()
-
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("ecdsa.GenerateKey: %v", err)
 	}
 
 	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
@@ -116,53 +71,18 @@ func computeFingerprint(t *testing.T, pub crypto.PublicKey) string {
 }
 
 // ---------------------------------------------------------------------------
-// Test Group 1: ed25519 signature type
+// ed25519 signature validation
 // ---------------------------------------------------------------------------
-
-func TestEd25519Signature(t *testing.T) {
-	blob := make([]byte, ed25519.SignatureSize)
-	for i := range blob {
-		blob[i] = byte(i)
-	}
-
-	sig, err := newEd25519Signature(blob)
-	if err != nil {
-		t.Fatalf("newEd25519Signature: %v", err)
-	}
-
-	if sig.SignatureType() != ED25519_SHA512 {
-		t.Errorf("SignatureType() = %q, want %q", sig.SignatureType(), ED25519_SHA512)
-	}
-
-	expected := base64.StdEncoding.EncodeToString(blob)
-	if sig.String() != expected {
-		t.Errorf("String() = %q, want %q", sig.String(), expected)
-	}
-}
 
 func TestEd25519SignatureValidation(t *testing.T) {
-	tests := []struct {
-		name string
-		blob []byte
-	}{
-		{"nil", nil},
-		{"empty", []byte{}},
-		{"too short", make([]byte, 32)},
-		{"too long", make([]byte, 128)},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := newEd25519Signature(tc.blob)
-			if err == nil {
-				t.Error("expected error for invalid signature length, got nil")
-			}
-		})
+	_, err := newEd25519Signature(make([]byte, 32))
+	if err == nil {
+		t.Error("expected error for invalid signature length, got nil")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Test Group 2: keyFormatToKeyType
+// keyFormatToKeyType
 // ---------------------------------------------------------------------------
 
 func TestKeyFormatToKeyType(t *testing.T) {
@@ -200,14 +120,12 @@ func TestKeyFormatToKeyType(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test Group 3: formatPublicKeyFingerprint
+// formatPublicKeyFingerprint — only new code paths
 // ---------------------------------------------------------------------------
 
 func TestFormatPublicKeyFingerprint(t *testing.T) {
-	rsaKey, _, rsaFP := generateRSAKey(t)
 	edKey, _, edFP := generateEd25519Key(t)
 
-	// Test ed25519 private key (the new code path)
 	t.Run("ed25519 private key", func(t *testing.T) {
 		got, err := formatPublicKeyFingerprint(edKey, true)
 		if err != nil {
@@ -218,7 +136,6 @@ func TestFormatPublicKeyFingerprint(t *testing.T) {
 		}
 	})
 
-	// Test ed25519 raw hex (display=false)
 	t.Run("ed25519 raw hex", func(t *testing.T) {
 		got, err := formatPublicKeyFingerprint(edKey, false)
 		if err != nil {
@@ -230,30 +147,6 @@ func TestFormatPublicKeyFingerprint(t *testing.T) {
 		}
 	})
 
-	// Test RSA private key
-	t.Run("rsa private key", func(t *testing.T) {
-		got, err := formatPublicKeyFingerprint(rsaKey, true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != rsaFP {
-			t.Errorf("fingerprint = %q, want %q", got, rsaFP)
-		}
-	})
-
-	// Test ecdsa private key
-	t.Run("ecdsa private key", func(t *testing.T) {
-		ecKey, _, ecFP := generateECDSAKey(t)
-		got, err := formatPublicKeyFingerprint(ecKey, true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != ecFP {
-			t.Errorf("fingerprint = %q, want %q", got, ecFP)
-		}
-	})
-
-	// Test ssh.PublicKey directly (the new case added in this branch)
 	t.Run("ssh.PublicKey", func(t *testing.T) {
 		sshPub, err := ssh.NewPublicKey(edKey.Public())
 		if err != nil {
@@ -268,7 +161,6 @@ func TestFormatPublicKeyFingerprint(t *testing.T) {
 		}
 	})
 
-	// Test unsupported type
 	t.Run("unsupported type", func(t *testing.T) {
 		_, err := formatPublicKeyFingerprint("not a key", false)
 		if err == nil {
@@ -278,11 +170,11 @@ func TestFormatPublicKeyFingerprint(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test Group 4: PrivateKeySigner
+// PrivateKeySigner with ed25519
 // ---------------------------------------------------------------------------
 
 func TestPrivateKeySignerEd25519(t *testing.T) {
-	_, pemBytes, fingerprint := generateEd25519Key(t)
+	priv, pemBytes, fingerprint := generateEd25519Key(t)
 
 	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
 		KeyID:              fingerprint,
@@ -304,52 +196,29 @@ func TestPrivateKeySignerEd25519(t *testing.T) {
 			t.Fatalf("Sign: %v", err)
 		}
 
-		if !strings.Contains(header, "ed25519-sha512") {
-			t.Errorf("Sign output missing algorithm, got: %s", header)
+		if !strings.HasPrefix(header, "Signature keyId=\"") {
+			t.Errorf("header should start with 'Signature keyId=\"', got: %s", header)
 		}
-		if !strings.Contains(header, "Signature keyId=") {
-			t.Errorf("Sign output missing keyId, got: %s", header)
+		if !strings.Contains(header, `algorithm="ed25519-sha512"`) {
+			t.Errorf("header missing algorithm, got: %s", header)
+		}
+		if !strings.Contains(header, `headers="date"`) {
+			t.Errorf("header missing headers field, got: %s", header)
 		}
 		if !strings.Contains(header, "testaccount") {
-			t.Errorf("Sign output missing account name, got: %s", header)
+			t.Errorf("header missing account name, got: %s", header)
 		}
 	})
 
-	t.Run("SignRaw", func(t *testing.T) {
-		signedBase64, algo, err := signer.SignRaw("test message")
+	t.Run("SignRaw verify", func(t *testing.T) {
+		message := "verify me"
+		signedBase64, algo, err := signer.SignRaw(message)
 		if err != nil {
 			t.Fatalf("SignRaw: %v", err)
 		}
 
 		if algo != ED25519_SHA512 {
 			t.Errorf("algorithm = %q, want %q", algo, ED25519_SHA512)
-		}
-
-		// Verify the signature is valid base64
-		_, err = base64.StdEncoding.DecodeString(signedBase64)
-		if err != nil {
-			t.Fatalf("invalid base64 in signature: %v", err)
-		}
-	})
-
-	t.Run("SignRaw verify", func(t *testing.T) {
-		// Generate a fresh key so we have access to the raw private key
-		// for verification.
-		priv, pemBytes2, fp2 := generateEd25519Key(t)
-
-		signer2, err := NewPrivateKeySigner(PrivateKeySignerInput{
-			KeyID:              fp2,
-			PrivateKeyMaterial: pemBytes2,
-			AccountName:        "testaccount",
-		})
-		if err != nil {
-			t.Fatalf("NewPrivateKeySigner: %v", err)
-		}
-
-		message := "verify me"
-		signedBase64, _, err := signer2.SignRaw(message)
-		if err != nil {
-			t.Fatalf("SignRaw: %v", err)
 		}
 
 		sigBytes, err := base64.StdEncoding.DecodeString(signedBase64)
@@ -362,56 +231,6 @@ func TestPrivateKeySignerEd25519(t *testing.T) {
 			t.Error("ed25519.Verify failed: signature is not valid")
 		}
 	})
-}
-
-func TestPrivateKeySignerRSA(t *testing.T) {
-	_, pemBytes, fingerprint := generateRSAKey(t)
-
-	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
-		KeyID:              fingerprint,
-		PrivateKeyMaterial: pemBytes,
-		AccountName:        "testaccount",
-	})
-	if err != nil {
-		t.Fatalf("NewPrivateKeySigner: %v", err)
-	}
-
-	if signer.DefaultAlgorithm() != RSA_SHA512 {
-		t.Errorf("DefaultAlgorithm() = %q, want %q", signer.DefaultAlgorithm(), RSA_SHA512)
-	}
-
-	header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
-	if err != nil {
-		t.Fatalf("Sign: %v", err)
-	}
-	if !strings.Contains(header, "rsa-sha512") {
-		t.Errorf("Sign output missing algorithm, got: %s", header)
-	}
-}
-
-func TestPrivateKeySignerECDSA(t *testing.T) {
-	_, pemBytes, fingerprint := generateECDSAKey(t)
-
-	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
-		KeyID:              fingerprint,
-		PrivateKeyMaterial: pemBytes,
-		AccountName:        "testaccount",
-	})
-	if err != nil {
-		t.Fatalf("NewPrivateKeySigner: %v", err)
-	}
-
-	if signer.DefaultAlgorithm() != ECDSA_SHA512 {
-		t.Errorf("DefaultAlgorithm() = %q, want %q", signer.DefaultAlgorithm(), ECDSA_SHA512)
-	}
-
-	header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
-	if err != nil {
-		t.Fatalf("Sign: %v", err)
-	}
-	if !strings.Contains(header, "ecdsa-sha512") {
-		t.Errorf("Sign output missing algorithm, got: %s", header)
-	}
 }
 
 func TestPrivateKeySignerBadFingerprint(t *testing.T) {
@@ -430,54 +249,8 @@ func TestPrivateKeySignerBadFingerprint(t *testing.T) {
 	}
 }
 
-func TestPrivateKeySignerBadKeyMaterial(t *testing.T) {
-	_, err := NewPrivateKeySigner(PrivateKeySignerInput{
-		KeyID:              "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-		PrivateKeyMaterial: []byte("not a valid key"),
-		AccountName:        "testaccount",
-	})
-	if err == nil {
-		t.Fatal("expected error for bad key material, got nil")
-	}
-}
-
-// Test that Sign() produces a consistent format by calling SignRaw() internally.
-func TestPrivateKeySignerSignConsistency(t *testing.T) {
-	_, pemBytes, fingerprint := generateEd25519Key(t)
-
-	signer, err := NewPrivateKeySigner(PrivateKeySignerInput{
-		KeyID:              fingerprint,
-		PrivateKeyMaterial: pemBytes,
-		AccountName:        "testaccount",
-		Username:           "testuser",
-	})
-	if err != nil {
-		t.Fatalf("NewPrivateKeySigner: %v", err)
-	}
-
-	// Sign should produce a properly formatted authorization header
-	header, err := signer.Sign("Thu, 01 Jan 2025 00:00:00 GMT", false)
-	if err != nil {
-		t.Fatalf("Sign: %v", err)
-	}
-
-	// Verify the header format
-	if !strings.HasPrefix(header, "Signature keyId=\"") {
-		t.Errorf("header should start with 'Signature keyId=\"', got: %s", header)
-	}
-	if !strings.Contains(header, `algorithm="ed25519-sha512"`) {
-		t.Errorf("header missing algorithm, got: %s", header)
-	}
-	if !strings.Contains(header, `headers="date"`) {
-		t.Errorf("header missing headers field, got: %s", header)
-	}
-	if !strings.Contains(header, `signature="`) {
-		t.Errorf("header missing signature field, got: %s", header)
-	}
-}
-
 // ---------------------------------------------------------------------------
-// Test Group 5: KeyID generation
+// KeyID generation
 // ---------------------------------------------------------------------------
 
 func TestKeyIDGenerate(t *testing.T) {

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -1,11 +1,9 @@
 //
+// Copyright 2026 Edgecast Cloud LLC.
+//
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-
-//
-// Copyright 2026 Edgecast Cloud LLC.
 //
 
 package authentication

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -5,7 +5,7 @@
 //
 
 //
-// Copyright 2025 Edgecast Cloud LLC.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 
 package authentication

--- a/authentication/ed25519_signature.go
+++ b/authentication/ed25519_signature.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Edgecast Cloud LLC.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/authentication/ed25519_signature.go
+++ b/authentication/ed25519_signature.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2025 Edgecast Cloud LLC.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package authentication
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+)
+
+type ed25519Signature struct {
+	signature []byte
+}
+
+func (s *ed25519Signature) SignatureType() string {
+	return ED25519_SHA512
+}
+
+func (s *ed25519Signature) String() string {
+	return base64.StdEncoding.EncodeToString(s.signature)
+}
+
+func newEd25519Signature(signatureBlob []byte) (*ed25519Signature, error) {
+	if len(signatureBlob) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("invalid ed25519 signature length: got %d, want %d",
+			len(signatureBlob), ed25519.SignatureSize)
+	}
+	return &ed25519Signature{
+		signature: signatureBlob,
+	}, nil
+}

--- a/authentication/private_key_signer.go
+++ b/authentication/private_key_signer.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
-// Copyright 2025 Edgecast Cloud LLC.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/authentication/private_key_signer.go
+++ b/authentication/private_key_signer.go
@@ -123,7 +123,7 @@ func (s *PrivateKeySigner) SignRaw(toSign string) (string, string, error) {
 		digest := hash.Sum(nil)
 		signed, err := rsa.SignPKCS1v15(rand.Reader, key, s.hashFunc, digest)
 		if err != nil {
-			return "", "", errors.Wrap(err, "failed create signature using RSA key")
+			return "", "", errors.Wrap(err, "failed to create signature using RSA key")
 		}
 		signedBase64 = base64.StdEncoding.EncodeToString(signed)
 	case *ecdsa.PrivateKey:
@@ -133,7 +133,7 @@ func (s *PrivateKeySigner) SignRaw(toSign string) (string, string, error) {
 		digest := hash.Sum(nil)
 		r, s, err := ecdsa.Sign(rand.Reader, key, digest)
 		if err != nil {
-			return "", "", errors.Wrap(err, "failed create signature using ECDSA key")
+			return "", "", errors.Wrap(err, "failed to create signature using ECDSA key")
 		}
 		signature := ECDSASignature{R: r, S: s}
 		signed, err := asn1.Marshal(signature)

--- a/authentication/private_key_signer.go
+++ b/authentication/private_key_signer.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
+// Copyright 2025 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,6 +12,7 @@ package authentication
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/asn1"
@@ -93,29 +95,10 @@ func NewPrivateKeySigner(input PrivateKeySignerInput) (*PrivateKeySigner, error)
 func (s *PrivateKeySigner) Sign(dateHeader string, isManta bool) (string, error) {
 	const headerName = "date"
 
-	hash := s.hashFunc.New()
-	hash.Write([]byte(fmt.Sprintf("%s: %s", headerName, dateHeader)))
-	digest := hash.Sum(nil)
-
-	var algoName string
-	var signedBase64 string
-	switch s.privateKey.(type) {
-	case *rsa.PrivateKey:
-		algoName = RSA_SHA512
-		signed, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey.(*rsa.PrivateKey), s.hashFunc, digest)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to sign date header")
-		}
-		signedBase64 = base64.StdEncoding.EncodeToString(signed)
-	case *ecdsa.PrivateKey:
-		algoName = ECDSA_SHA512
-		r, s, err := ecdsa.Sign(rand.Reader, s.privateKey.(*ecdsa.PrivateKey), digest)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to sign date header")
-		}
-		signature := ECDSASignature{R: r, S: s}
-		signed, err := asn1.Marshal(signature)
-		signedBase64 = base64.StdEncoding.EncodeToString(signed)
+	message := fmt.Sprintf("%s: %s", headerName, dateHeader)
+	signedBase64, algoName, err := s.SignRaw(message)
+	if err != nil {
+		return "", err
 	}
 
 	key := &KeyID{
@@ -129,30 +112,41 @@ func (s *PrivateKeySigner) Sign(dateHeader string, isManta bool) (string, error)
 }
 
 func (s *PrivateKeySigner) SignRaw(toSign string) (string, string, error) {
-	hash := s.hashFunc.New()
-	hash.Write([]byte(toSign))
-	digest := hash.Sum(nil)
-
 	var algoName string
 	var signedBase64 string
-	switch s.privateKey.(type) {
+	message := []byte(toSign)
+	switch key := s.privateKey.(type) {
 	case *rsa.PrivateKey:
 		algoName = RSA_SHA512
-		signed, err := rsa.SignPKCS1v15(rand.Reader, s.privateKey.(*rsa.PrivateKey), s.hashFunc, digest)
+		hash := s.hashFunc.New()
+		hash.Write(message)
+		digest := hash.Sum(nil)
+		signed, err := rsa.SignPKCS1v15(rand.Reader, key, s.hashFunc, digest)
 		if err != nil {
 			return "", "", errors.Wrap(err, "unable to sign date header")
 		}
 		signedBase64 = base64.StdEncoding.EncodeToString(signed)
 	case *ecdsa.PrivateKey:
 		algoName = ECDSA_SHA512
-		r, s, err := ecdsa.Sign(rand.Reader, s.privateKey.(*ecdsa.PrivateKey), digest)
+		hash := s.hashFunc.New()
+		hash.Write(message)
+		digest := hash.Sum(nil)
+		r, s, err := ecdsa.Sign(rand.Reader, key, digest)
 		if err != nil {
 			return "", "", errors.Wrap(err, "unable to sign date header")
 		}
 		signature := ECDSASignature{R: r, S: s}
 		signed, err := asn1.Marshal(signature)
+		if err != nil {
+			return "", "", errors.Wrap(err, "unable to marshal ECDSA signature")
+		}
 		signedBase64 = base64.StdEncoding.EncodeToString(signed)
-
+	case ed25519.PrivateKey:
+		algoName = ED25519_SHA512
+		signed := ed25519.Sign(key, message)
+		signedBase64 = base64.StdEncoding.EncodeToString(signed)
+	default:
+		return "", "", errors.New("unable to sign string with unsupported key type")
 	}
 
 	return signedBase64, algoName, nil

--- a/authentication/private_key_signer.go
+++ b/authentication/private_key_signer.go
@@ -123,7 +123,7 @@ func (s *PrivateKeySigner) SignRaw(toSign string) (string, string, error) {
 		digest := hash.Sum(nil)
 		signed, err := rsa.SignPKCS1v15(rand.Reader, key, s.hashFunc, digest)
 		if err != nil {
-			return "", "", errors.Wrap(err, "unable to sign date header")
+			return "", "", errors.Wrap(err, "failed create signature using RSA key")
 		}
 		signedBase64 = base64.StdEncoding.EncodeToString(signed)
 	case *ecdsa.PrivateKey:
@@ -133,7 +133,7 @@ func (s *PrivateKeySigner) SignRaw(toSign string) (string, string, error) {
 		digest := hash.Sum(nil)
 		r, s, err := ecdsa.Sign(rand.Reader, key, digest)
 		if err != nil {
-			return "", "", errors.Wrap(err, "unable to sign date header")
+			return "", "", errors.Wrap(err, "failed create signature using ECDSA key")
 		}
 		signature := ECDSASignature{R: r, S: s}
 		signed, err := asn1.Marshal(signature)

--- a/authentication/ssh_agent_signer.go
+++ b/authentication/ssh_agent_signer.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
-// Copyright 2025 Edgecast Cloud LLC.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/authentication/ssh_agent_signer.go
+++ b/authentication/ssh_agent_signer.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
+// Copyright 2025 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -18,13 +19,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	pkgerrors "github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
 
 var (
-	ErrUnsetEnvVar = pkgerrors.New("environment variable SSH_AUTH_SOCK not set")
+	ErrUnsetEnvVar = errors.New("environment variable SSH_AUTH_SOCK not set")
 )
 
 type SSHAgentSigner struct {
@@ -53,7 +53,7 @@ func NewSSHAgentSigner(input SSHAgentSignerInput) (*SSHAgentSigner, error) {
 
 	conn, err := net.Dial("unix", sshAgentAddress)
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "unable to dial SSH agent")
+		return nil, errors.Wrap(err, "unable to dial SSH agent")
 	}
 
 	ag := agent.NewClient(conn)
@@ -90,7 +90,7 @@ func NewSSHAgentSigner(input SSHAgentSignerInput) (*SSHAgentSigner, error) {
 func (s *SSHAgentSigner) MatchKey() (ssh.PublicKey, error) {
 	keys, err := s.agent.List()
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "unable to list keys in SSH Agent")
+		return nil, errors.Wrap(err, "unable to list keys in SSH Agent")
 	}
 
 	keyFingerprintStripped := strings.TrimPrefix(s.keyFingerprint, "MD5:")
@@ -124,12 +124,12 @@ func (s *SSHAgentSigner) Sign(dateHeader string, isManta bool) (string, error) {
 
 	signature, err := s.agent.Sign(s.key, []byte(fmt.Sprintf("%s: %s", headerName, dateHeader)))
 	if err != nil {
-		return "", pkgerrors.Wrap(err, "unable to sign date header")
+		return "", errors.Wrap(err, "unable to sign date header")
 	}
 
 	keyFormat, err := keyFormatToKeyType(signature.Format)
 	if err != nil {
-		return "", pkgerrors.Wrap(err, "unable to format signature")
+		return "", errors.Wrap(err, "unable to format signature")
 	}
 
 	key := &KeyID{
@@ -144,12 +144,17 @@ func (s *SSHAgentSigner) Sign(dateHeader string, isManta bool) (string, error) {
 	case "rsa":
 		authSignature, err = newRSASignature(signature.Blob)
 		if err != nil {
-			return "", pkgerrors.Wrap(err, "unable to read RSA signature")
+			return "", errors.Wrap(err, "unable to read RSA signature")
 		}
 	case "ecdsa":
 		authSignature, err = newECDSASignature(signature.Blob)
 		if err != nil {
-			return "", pkgerrors.Wrap(err, "unable to read ECDSA signature")
+			return "", errors.Wrap(err, "unable to read ECDSA signature")
+		}
+	case "ed25519":
+		authSignature, err = newEd25519Signature(signature.Blob)
+		if err != nil {
+			return "", errors.Wrap(err, "unable to read Ed25519 signature")
 		}
 	default:
 		return "", fmt.Errorf("Unsupported algorithm from SSH agent: %s", signature.Format)
@@ -162,12 +167,12 @@ func (s *SSHAgentSigner) Sign(dateHeader string, isManta bool) (string, error) {
 func (s *SSHAgentSigner) SignRaw(toSign string) (string, string, error) {
 	signature, err := s.agent.Sign(s.key, []byte(toSign))
 	if err != nil {
-		return "", "", pkgerrors.Wrap(err, "unable to sign string")
+		return "", "", errors.Wrap(err, "unable to sign string")
 	}
 
 	keyFormat, err := keyFormatToKeyType(signature.Format)
 	if err != nil {
-		return "", "", pkgerrors.Wrap(err, "unable to format key")
+		return "", "", errors.Wrap(err, "unable to format key")
 	}
 
 	var authSignature httpAuthSignature
@@ -175,12 +180,17 @@ func (s *SSHAgentSigner) SignRaw(toSign string) (string, string, error) {
 	case "rsa":
 		authSignature, err = newRSASignature(signature.Blob)
 		if err != nil {
-			return "", "", pkgerrors.Wrap(err, "unable to read RSA signature")
+			return "", "", errors.Wrap(err, "unable to read RSA signature")
 		}
 	case "ecdsa":
 		authSignature, err = newECDSASignature(signature.Blob)
 		if err != nil {
-			return "", "", pkgerrors.Wrap(err, "unable to read ECDSA signature")
+			return "", "", errors.Wrap(err, "unable to read ECDSA signature")
+		}
+	case "ed25519":
+		authSignature, err = newEd25519Signature(signature.Blob)
+		if err != nil {
+			return "", "", errors.Wrap(err, "unable to read Ed25519 signature")
 		}
 	default:
 		return "", "", fmt.Errorf("Unsupported algorithm from SSH agent: %s", signature.Format)

--- a/authentication/util.go
+++ b/authentication/util.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
-// Copyright 2025 Edgecast Cloud LLC.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/authentication/util.go
+++ b/authentication/util.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2018, Joyent, Inc. All rights reserved.
+// Copyright 2025 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,6 +11,7 @@ package authentication
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/md5"
 	"crypto/rsa"
 	"fmt"
@@ -24,22 +26,29 @@ import (
 // between each byte, as per the output of OpenSSL.
 func formatPublicKeyFingerprint(privateKey interface{}, display bool) (string, error) {
 	var key ssh.PublicKey
-	switch privateKey.(type) {
+	switch k := privateKey.(type) {
+	case ssh.PublicKey:
+		key = k
 	case *rsa.PrivateKey:
-		p, err := ssh.NewPublicKey(privateKey.(*rsa.PrivateKey).Public())
+		p, err := ssh.NewPublicKey(k.Public())
 		if err != nil {
 			return "", errors.Wrap(err, "unable to parse SSH key from private key")
 		}
 		key = p
 	case *ecdsa.PrivateKey:
-		p, err := ssh.NewPublicKey(privateKey.(*ecdsa.PrivateKey).Public())
+		p, err := ssh.NewPublicKey(k.Public())
+		if err != nil {
+			return "", errors.Wrap(err, "unable to parse SSH key from private key")
+		}
+		key = p
+	case ed25519.PrivateKey:
+		p, err := ssh.NewPublicKey(k.Public())
 		if err != nil {
 			return "", errors.Wrap(err, "unable to parse SSH key from private key")
 		}
 		key = p
 	default:
 		return "", fmt.Errorf("unable to parse SSH key from private key")
-
 	}
 	publicKeyFingerprint := md5.New()
 	publicKeyFingerprint.Write(key.Marshal())

--- a/cmd/manta/cmd/version/public.go
+++ b/cmd/manta/cmd/version/public.go
@@ -1,6 +1,7 @@
 //
 //  Copyright 2020 Joyent, Inc. All rights reserved.
 //  Copyright 2025 MNX Cloud, Inc.
+//  Copyright 2026 Edgecast Cloud LLC.
 //
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,7 +27,17 @@ var Cmd = &command.Command{
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cons := conswriter.GetTerminal()
-			cons.Write([]byte(fmt.Sprintf("Version: %s\n", triton.UserAgent())))
+			fmt.Fprintf(cons, "Version: %s\n", triton.UserAgent())
+			bi := triton.BuildInfo()
+			if bi.Revision != "" {
+				fmt.Fprintf(cons, "Revision: %s\n", bi.Revision)
+			}
+			if bi.Time != "" {
+				fmt.Fprintf(cons, "Build Time: %s\n", bi.Time)
+			}
+			if bi.Modified {
+				fmt.Fprintf(cons, "Modified: true\n")
+			}
 			return nil
 		},
 	},

--- a/cmd/triton/cmd/version/public.go
+++ b/cmd/triton/cmd/version/public.go
@@ -1,6 +1,7 @@
 //
 //  Copyright 2020 Joyent, Inc. All rights reserved.
 //  Copyright 2025 MNX Cloud, Inc.
+//  Copyright 2026 Edgecast Cloud LLC.
 //
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,7 +27,17 @@ var Cmd = &command.Command{
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cons := conswriter.GetTerminal()
-			cons.Write([]byte(fmt.Sprintf("Version: %s\n", triton.UserAgent())))
+			fmt.Fprintf(cons, "Version: %s\n", triton.UserAgent())
+			bi := triton.BuildInfo()
+			if bi.Revision != "" {
+				fmt.Fprintf(cons, "Revision: %s\n", bi.Revision)
+			}
+			if bi.Time != "" {
+				fmt.Fprintf(cons, "Build Time: %s\n", bi.Time)
+			}
+			if bi.Modified {
+				fmt.Fprintf(cons, "Modified: true\n")
+			}
 			return nil
 		},
 	},

--- a/compute/images.go
+++ b/compute/images.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -45,7 +46,7 @@ type Image struct {
 	Owner        string                 `json:"owner"`
 	Public       bool                   `json:"public"`
 	State        string                 `json:"state"`
-	Tags         map[string]string      `json:"tags"`
+	Tags         map[string]interface{} `json:"tags"`
 	EULA         string                 `json:"eula"`
 	ACL          []string               `json:"acl"`
 }
@@ -195,14 +196,14 @@ func (c *ImagesClient) Export(ctx context.Context, input *ExportImageInput) (*Ma
 }
 
 type CreateImageFromMachineInput struct {
-	MachineID   string            `json:"machine"`
-	Name        string            `json:"name"`
-	Version     string            `json:"version,omitempty"`
-	Description string            `json:"description,omitempty"`
-	HomePage    string            `json:"homepage,omitempty"`
-	EULA        string            `json:"eula,omitempty"`
-	ACL         []string          `json:"acl,omitempty"`
-	Tags        map[string]string `json:"tags,omitempty"`
+	MachineID   string                 `json:"machine"`
+	Name        string                 `json:"name"`
+	Version     string                 `json:"version,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	HomePage    string                 `json:"homepage,omitempty"`
+	EULA        string                 `json:"eula,omitempty"`
+	ACL         []string               `json:"acl,omitempty"`
+	Tags        map[string]interface{} `json:"tags,omitempty"`
 }
 
 func (c *ImagesClient) CreateFromMachine(ctx context.Context, input *CreateImageFromMachineInput) (*Image, error) {
@@ -230,14 +231,14 @@ func (c *ImagesClient) CreateFromMachine(ctx context.Context, input *CreateImage
 }
 
 type UpdateImageInput struct {
-	ImageID     string            `json:"-"`
-	Name        string            `json:"name,omitempty"`
-	Version     string            `json:"version,omitempty"`
-	Description string            `json:"description,omitempty"`
-	HomePage    string            `json:"homepage,omitempty"`
-	EULA        string            `json:"eula,omitempty"`
-	ACL         []string          `json:"acl,omitempty"`
-	Tags        map[string]string `json:"tags,omitempty"`
+	ImageID     string                 `json:"-"`
+	Name        string                 `json:"name,omitempty"`
+	Version     string                 `json:"version,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	HomePage    string                 `json:"homepage,omitempty"`
+	EULA        string                 `json:"eula,omitempty"`
+	ACL         []string               `json:"acl,omitempty"`
+	Tags        map[string]interface{} `json:"tags,omitempty"`
 }
 
 func (c *ImagesClient) Update(ctx context.Context, input *UpdateImageInput) (*Image, error) {

--- a/compute/images_test.go
+++ b/compute/images_test.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -281,6 +282,59 @@ func TestGetImage(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "unable to get image") {
 			t.Errorf("expected error to equal testError: found %s", err)
+		}
+	})
+}
+
+func TestGetImageMixedTags(t *testing.T) {
+	computeClient := MockComputeClient()
+
+	do := func(ctx context.Context, cc *compute.ComputeClient) (*compute.Image, error) {
+		defer testutils.DeactivateClient()
+
+		image, err := cc.Images().Get(ctx, &compute.GetImageInput{
+			ImageID: fakeImageID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return image, nil
+	}
+
+	t.Run("successful", func(t *testing.T) {
+		testutils.RegisterResponder("GET", path.Join("/", accountURL, "images", fakeImageID), getImageMixedTagsSuccess)
+
+		resp, err := do(context.Background(), computeClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp == nil {
+			t.Fatalf("Expected an output but got nil")
+		}
+
+		tagVal, ok := resp.Tags["role"]
+		if !ok {
+			t.Fatalf("Expected image to have tag \"role\": found %v", resp.Tags)
+		}
+		if tagVal != "os" {
+			t.Fatalf("Expected tag \"role\" to equal \"os\": found %v", tagVal)
+		}
+
+		tagVal, ok = resp.Tags["production"]
+		if !ok {
+			t.Fatalf("Expected image to have tag \"production\": found %v", resp.Tags)
+		}
+		if tagVal != true {
+			t.Fatalf("Expected tag \"production\" to equal true: found %v", tagVal)
+		}
+
+		tagVal, ok = resp.Tags["priority"]
+		if !ok {
+			t.Fatalf("Expected image to have tag \"priority\": found %v", resp.Tags)
+		}
+		if tagVal != float64(42) {
+			t.Fatalf("Expected tag \"priority\" to equal 42: found %v", tagVal)
 		}
 	})
 }
@@ -576,6 +630,45 @@ func getImageEmpty(req *http.Request) (*http.Response, error) {
 
 func getImageError(req *http.Request) (*http.Response, error) {
 	return nil, errors.New("unable to get image")
+}
+
+func getImageMixedTagsSuccess(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Add("Content-Type", "application/json")
+
+	body := strings.NewReader(`{
+  "id": "8adac45a-aca7-11ee-b53e-00151714048c",
+  "name": "base-64-lts",
+  "version": "23.4.0",
+  "os": "smartos",
+  "requirements": {},
+  "type": "zone-dataset",
+  "description": "A 64-bit SmartOS image with just essential packages installed.",
+  "files": [
+	{
+	  "compression": "gzip",
+	  "sha1": "b9ffbab72b94a22575e056923cd3e6c0dd905a2b",
+	  "size": 239035529
+	}
+  ],
+  "tags": {
+	"role": "os",
+	"production": true,
+	"priority": 42
+  },
+  "homepage": "https://docs.tritondatacenter.com/public-cloud/instances/infrastructure/images/smartos/base",
+  "published_at": "2024-01-06T15:23:28Z",
+  "owner": "930896af-bf8c-48d4-885c-6573a94b1853",
+  "public": true,
+  "state": "active"
+}
+`)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       ioutil.NopCloser(body),
+	}, nil
 }
 
 func listImagesSuccess(req *http.Request) (*http.Response, error) {

--- a/examples/compute/create_instance_with_volumes/main.go
+++ b/examples/compute/create_instance_with_volumes/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/compute/create_instance_with_volumes/main.go
+++ b/examples/compute/create_instance_with_volumes/main.go
@@ -180,6 +180,8 @@ func main() {
 
 	// Create a new instance using our input attributes...
 	// https://github.com/TritonDataCenter/triton-go/v2/blob/master/compute/instances.go#L206
+	tagsInput := make(map[string]interface{}, 1)
+	tagsInput["tag1"] = "value1"
 	createInput := &compute.CreateInstanceInput{
 		Name:     testutils.RandString(10),
 		Package:  PackageName,
@@ -188,9 +190,7 @@ func main() {
 		Volumes: []compute.InstanceVolume{
 			instanceVolume,
 		},
-		Tags: map[string]string{
-			"tag1": "value1",
-		},
+		Tags: tagsInput,
 	}
 
 	created, err := c.Instances().Create(context.Background(), createInput)

--- a/examples/services/groups/list_groups.go
+++ b/examples/services/groups/list_groups.go
@@ -1,11 +1,16 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
+
+// NOTE: Triton Service Groups (TSG) was a standalone microservice for
+// auto-scaling instance groups that never left preview status. This example
+// targets a separate TSG API server (via TRITON_TSG_URL), not CloudAPI.
 
 package main
 

--- a/examples/services/templates/list_templates.go
+++ b/examples/services/templates/list_templates.go
@@ -1,11 +1,16 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
+
+// NOTE: Triton Service Groups (TSG) was a standalone microservice for
+// auto-scaling instance groups that never left preview status. This example
+// targets a separate TSG API server (via TRITON_TSG_URL), not CloudAPI.
 
 package main
 

--- a/examples/storage/create_job/main.go
+++ b/examples/storage/create_job/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -26,9 +27,9 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	accountName := os.Getenv("TRITON_ACCOUNT")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	accountName := os.Getenv("MANTA_USER")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	userName := os.Getenv("TRITON_USER")
 
 	var signer authentication.Signer
@@ -81,7 +82,7 @@ func main() {
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("TRITON_URL"),
+		MantaURL:    os.Getenv("MANTA_URL"),
 		AccountName: accountName,
 		Username:    userName,
 		Signers:     []authentication.Signer{signer},

--- a/examples/storage/create_job/main.go
+++ b/examples/storage/create_job/main.go
@@ -30,7 +30,7 @@ func main() {
 	keyID := os.Getenv("MANTA_KEY_ID")
 	accountName := os.Getenv("MANTA_USER")
 	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 
 	var signer authentication.Signer
 	var err error

--- a/examples/storage/create_mpu/main.go
+++ b/examples/storage/create_mpu/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -25,9 +26,9 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	accountName := os.Getenv("TRITON_ACCOUNT")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	accountName := os.Getenv("MANTA_USER")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	userName := os.Getenv("TRITON_USER")
 	fileName := "foo.txt"
 	localPath := "/tmp/" + fileName

--- a/examples/storage/create_mpu/main.go
+++ b/examples/storage/create_mpu/main.go
@@ -29,7 +29,7 @@ func main() {
 	keyID := os.Getenv("MANTA_KEY_ID")
 	accountName := os.Getenv("MANTA_USER")
 	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 	fileName := "foo.txt"
 	localPath := "/tmp/" + fileName
 	mantaPath := "/stor/bar/baz/" + fileName

--- a/examples/storage/force_delete/main.go
+++ b/examples/storage/force_delete/main.go
@@ -26,11 +26,11 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	mantaUser := os.Getenv("MANTA_USER")
 	mantaFolder := os.Getenv("MANTA_FOLDER")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 
 	if mantaFolder == "" {
 		log.Fatal("MANTA_FOLDER must be set")

--- a/examples/storage/force_delete/main.go
+++ b/examples/storage/force_delete/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -30,6 +31,10 @@ func main() {
 	mantaUser := os.Getenv("MANTA_USER")
 	mantaFolder := os.Getenv("MANTA_FOLDER")
 	userName := os.Getenv("TRITON_USER")
+
+	if mantaFolder == "" {
+		log.Fatal("MANTA_FOLDER must be set")
+	}
 
 	var signer authentication.Signer
 	var err error

--- a/examples/storage/force_put/main.go
+++ b/examples/storage/force_put/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/storage/force_put/main.go
+++ b/examples/storage/force_put/main.go
@@ -25,10 +25,10 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	mantaUser := os.Getenv("MANTA_USER")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 
 	var signer authentication.Signer
 	var err error

--- a/examples/storage/get_object/main.go
+++ b/examples/storage/get_object/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/storage/get_object/main.go
+++ b/examples/storage/get_object/main.go
@@ -34,7 +34,7 @@ func main() {
 		keyID       = os.Getenv("MANTA_KEY_ID")
 		accountName = os.Getenv("MANTA_USER")
 		keyMaterial = os.Getenv("MANTA_KEY_MATERIAL")
-		userName    = os.Getenv("TRITON_USER")
+		userName    = os.Getenv("MANTA_SUBUSER")
 	)
 
 	if keyMaterial == "" {

--- a/examples/storage/list_directory/main.go
+++ b/examples/storage/list_directory/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/storage/list_directory/main.go
+++ b/examples/storage/list_directory/main.go
@@ -32,7 +32,7 @@ func main() {
 		keyID       = os.Getenv("MANTA_KEY_ID")
 		accountName = os.Getenv("MANTA_USER")
 		keyMaterial = os.Getenv("MANTA_KEY_MATERIAL")
-		userName    = os.Getenv("TRITON_USER")
+		userName    = os.Getenv("MANTA_SUBUSER")
 	)
 
 	if keyMaterial == "" {

--- a/examples/storage/mls/main.go
+++ b/examples/storage/mls/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,9 +25,9 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	accountName := os.Getenv("TRITON_ACCOUNT")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	accountName := os.Getenv("MANTA_USER")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	userName := os.Getenv("TRITON_USER")
 
 	var signer authentication.Signer
@@ -79,7 +80,7 @@ func main() {
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("TRITON_URL"),
+		MantaURL:    os.Getenv("MANTA_URL"),
 		AccountName: accountName,
 		Username:    userName,
 		Signers:     []authentication.Signer{signer},

--- a/examples/storage/mls/main.go
+++ b/examples/storage/mls/main.go
@@ -28,7 +28,7 @@ func main() {
 	keyID := os.Getenv("MANTA_KEY_ID")
 	accountName := os.Getenv("MANTA_USER")
 	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 
 	var signer authentication.Signer
 	var err error

--- a/examples/storage/object_put/main.go
+++ b/examples/storage/object_put/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,9 +25,9 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	accountName := os.Getenv("TRITON_ACCOUNT")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	accountName := os.Getenv("MANTA_USER")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	userName := os.Getenv("TRITON_USER")
 
 	var signer authentication.Signer
@@ -79,7 +80,7 @@ func main() {
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("TRITON_URL"),
+		MantaURL:    os.Getenv("MANTA_URL"),
 		AccountName: accountName,
 		Username:    userName,
 		Signers:     []authentication.Signer{signer},

--- a/examples/storage/object_put/main.go
+++ b/examples/storage/object_put/main.go
@@ -28,7 +28,7 @@ func main() {
 	keyID := os.Getenv("MANTA_KEY_ID")
 	accountName := os.Getenv("MANTA_USER")
 	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 
 	var signer authentication.Signer
 	var err error

--- a/examples/storage/sign_url/main.go
+++ b/examples/storage/sign_url/main.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,9 +25,9 @@ import (
 )
 
 func main() {
-	keyID := os.Getenv("TRITON_KEY_ID")
-	accountName := os.Getenv("TRITON_ACCOUNT")
-	keyMaterial := os.Getenv("TRITON_KEY_MATERIAL")
+	keyID := os.Getenv("MANTA_KEY_ID")
+	accountName := os.Getenv("MANTA_USER")
+	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
 	userName := os.Getenv("TRITON_USER")
 
 	var signer authentication.Signer
@@ -79,7 +80,7 @@ func main() {
 	}
 
 	config := &triton.ClientConfig{
-		MantaURL:    os.Getenv("TRITON_URL"),
+		MantaURL:    os.Getenv("MANTA_URL"),
 		AccountName: accountName,
 		Username:    userName,
 		Signers:     []authentication.Signer{signer},

--- a/examples/storage/sign_url/main.go
+++ b/examples/storage/sign_url/main.go
@@ -28,7 +28,7 @@ func main() {
 	keyID := os.Getenv("MANTA_KEY_ID")
 	accountName := os.Getenv("MANTA_USER")
 	keyMaterial := os.Getenv("MANTA_KEY_MATERIAL")
-	userName := os.Getenv("TRITON_USER")
+	userName := os.Getenv("MANTA_SUBUSER")
 
 	var signer authentication.Signer
 	var err error

--- a/storage/delete_test.go
+++ b/storage/delete_test.go
@@ -173,3 +173,40 @@ func TestForceDeleteNestedDirectory(t *testing.T) {
 		}
 	}
 }
+
+// TestDeleteDirectorySimple verifies that Delete with ForceDelete: false
+// issues a single DELETE request without listing or recursing.
+func TestDeleteDirectorySimple(t *testing.T) {
+	storageClient := MockStorageClient()
+	defer testutils.DeactivateClient()
+
+	var mu sync.Mutex
+	deleted := make(map[string]bool)
+	track := deleteTracker(&mu, deleted)
+
+	dirPath := path.Join("/", accountURL, "stor/emptydir")
+
+	// If a GET (directory listing) is issued, the test should fail.
+	testutils.RegisterResponder("GET", dirPath,
+		func(req *http.Request) (*http.Response, error) {
+			t.Fatal("unexpected directory listing request; ForceDelete is false")
+			return nil, nil
+		})
+
+	testutils.RegisterResponder("DELETE", dirPath, track)
+
+	err := storageClient.Dir().Delete(context.Background(), &storage.DeleteDirectoryInput{
+		DirectoryName: "/stor/emptydir",
+		ForceDelete:   false,
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if !deleted[dirPath] {
+		t.Errorf("expected DELETE for %q but it was not called", dirPath)
+	}
+	if len(deleted) != 1 {
+		t.Errorf("expected exactly 1 DELETE, got %d: %v", len(deleted), deleted)
+	}
+}

--- a/storage/delete_test.go
+++ b/storage/delete_test.go
@@ -1,0 +1,175 @@
+//
+// Copyright 2026 Edgecast Cloud LLC.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/TritonDataCenter/triton-go/v2/storage"
+	"github.com/TritonDataCenter/triton-go/v2/testutils"
+)
+
+// dirEntry is a helper for building mock directory listings.
+type dirEntry struct {
+	Name string
+	Type string // "directory" or "object"
+}
+
+// makeDirListing returns a newline-delimited JSON stream matching the format
+// that Manta returns for directory listings (application/x-json-stream).
+func makeDirListing(entries []dirEntry) string {
+	var lines []string
+	for _, e := range entries {
+		lines = append(lines,
+			fmt.Sprintf(`{"name":%q,"type":%q,"mtime":"2025-01-01T00:00:00.000Z"}`,
+				e.Name, e.Type))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// deleteTracker returns a responder that records each DELETE request path and
+// replies with 204 No Content.
+func deleteTracker(mu *sync.Mutex, deleted map[string]bool) testutils.Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		deleted[req.URL.Path] = true
+		mu.Unlock()
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+		}, nil
+	}
+}
+
+// listResponder returns a responder that serves a directory listing.
+func listResponder(entries []dirEntry) testutils.Responder {
+	body := makeDirListing(entries)
+	count := fmt.Sprintf("%d", len(entries))
+	return func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Type", "application/x-json-stream")
+		header.Set("Result-Set-Size", count)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       ioutil.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+}
+
+// TestForceDeleteMultipleObjects verifies that ForceDelete removes every object
+// in a directory, not just the first one. It also checks that the target
+// directory itself is deleted after its contents are removed.
+func TestForceDeleteMultipleObjects(t *testing.T) {
+	storageClient := MockStorageClient()
+	defer testutils.DeactivateClient()
+
+	var mu sync.Mutex
+	deleted := make(map[string]bool)
+	track := deleteTracker(&mu, deleted)
+
+	// Directory listing: two objects
+	testutils.RegisterResponder("GET",
+		path.Join("/", accountURL, "stor/mydir"),
+		listResponder([]dirEntry{
+			{"file1.txt", "object"},
+			{"file2.txt", "object"},
+		}))
+
+	// DELETE responders for the two objects and the directory itself
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir/file1.txt"), track)
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir/file2.txt"), track)
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir"), track)
+
+	err := storageClient.Dir().Delete(context.Background(), &storage.DeleteDirectoryInput{
+		DirectoryName: "/stor/mydir",
+		ForceDelete:   true,
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Both objects must have been deleted
+	expect := []string{
+		path.Join("/", accountURL, "stor/mydir/file1.txt"),
+		path.Join("/", accountURL, "stor/mydir/file2.txt"),
+		path.Join("/", accountURL, "stor/mydir"),
+	}
+	for _, p := range expect {
+		if !deleted[p] {
+			t.Errorf("expected DELETE for %q but it was not called", p)
+		}
+	}
+}
+
+// TestForceDeleteNestedDirectory verifies that ForceDelete recurses into
+// subdirectories and deletes the entire tree.
+func TestForceDeleteNestedDirectory(t *testing.T) {
+	storageClient := MockStorageClient()
+	defer testutils.DeactivateClient()
+
+	var mu sync.Mutex
+	deleted := make(map[string]bool)
+	track := deleteTracker(&mu, deleted)
+
+	// Top-level listing: one subdirectory and one object
+	testutils.RegisterResponder("GET",
+		path.Join("/", accountURL, "stor/mydir"),
+		listResponder([]dirEntry{
+			{"subdir", "directory"},
+			{"file1.txt", "object"},
+		}))
+
+	// Subdirectory listing: one object
+	testutils.RegisterResponder("GET",
+		path.Join("/", accountURL, "stor/mydir/subdir"),
+		listResponder([]dirEntry{
+			{"file3.txt", "object"},
+		}))
+
+	// DELETE responders for all four paths
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir/subdir/file3.txt"), track)
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir/subdir"), track)
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir/file1.txt"), track)
+	testutils.RegisterResponder("DELETE",
+		path.Join("/", accountURL, "stor/mydir"), track)
+
+	err := storageClient.Dir().Delete(context.Background(), &storage.DeleteDirectoryInput{
+		DirectoryName: "/stor/mydir",
+		ForceDelete:   true,
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	expect := []string{
+		path.Join("/", accountURL, "stor/mydir/subdir/file3.txt"),
+		path.Join("/", accountURL, "stor/mydir/subdir"),
+		path.Join("/", accountURL, "stor/mydir/file1.txt"),
+		path.Join("/", accountURL, "stor/mydir"),
+	}
+	for _, p := range expect {
+		if !deleted[p] {
+			t.Errorf("expected DELETE for %q but it was not called", p)
+		}
+	}
+}

--- a/storage/directory.go
+++ b/storage/directory.go
@@ -133,11 +133,11 @@ func (s *DirectoryClient) Put(ctx context.Context, input *PutDirectoryInput) err
 // DeleteDirectoryInput represents parameters to a Delete operation.
 type DeleteDirectoryInput struct {
 	DirectoryName string
-	ForceDelete   bool //Will recursively delete all child directories and objects
+	ForceDelete   bool // Recursively delete all child directories and objects
 }
 
-// Delete deletes a directory on the Triton Object Storage. The directory must
-// be empty.
+// Delete deletes a directory on the Triton Object Storage. If ForceDelete is
+// false, the directory must be empty.
 func (s *DirectoryClient) Delete(ctx context.Context, input *DeleteDirectoryInput) error {
 	absPath := absFileInput(s.client.AccountName, input.DirectoryName)
 

--- a/storage/directory.go
+++ b/storage/directory.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc. All rights reserved.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -141,18 +142,13 @@ func (s *DirectoryClient) Delete(ctx context.Context, input *DeleteDirectoryInpu
 	absPath := absFileInput(s.client.AccountName, input.DirectoryName)
 
 	if input.ForceDelete {
-		err := deleteAll(*s, ctx, absPath)
-		if err != nil {
+		if err := deleteAll(*s, ctx, absPath); err != nil {
 			return err
 		}
-	} else {
-		err := deleteDirectory(*s, ctx, absPath)
-		if err != nil {
-			return err
-		}
+		return deleteDirectory(*s, ctx, absPath)
 	}
 
-	return nil
+	return deleteDirectory(*s, ctx, absPath)
 }
 
 func deleteAll(c DirectoryClient, ctx context.Context, directoryPath _AbsCleanPath) error {
@@ -165,12 +161,16 @@ func deleteAll(c DirectoryClient, ctx context.Context, directoryPath _AbsCleanPa
 	for _, obj := range objs.Entries {
 		newPath := absFileInput(c.client.AccountName, path.Join(string(directoryPath), obj.Name))
 		if obj.Type == "directory" {
-			err := deleteDirectory(c, ctx, newPath)
-			if err != nil {
-				return deleteAll(c, ctx, newPath)
+			if err := deleteAll(c, ctx, newPath); err != nil {
+				return err
+			}
+			if err := deleteDirectory(c, ctx, newPath); err != nil {
+				return err
 			}
 		} else {
-			return deleteObject(c, ctx, newPath)
+			if err := deleteObject(c, ctx, newPath); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/storage/storage_acc_test.go
+++ b/storage/storage_acc_test.go
@@ -1,0 +1,277 @@
+//
+// Copyright 2026 Edgecast Cloud LLC.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+package storage_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	triton "github.com/TritonDataCenter/triton-go/v2"
+	"github.com/TritonDataCenter/triton-go/v2/authentication"
+	terrors "github.com/TritonDataCenter/triton-go/v2/errors"
+	"github.com/TritonDataCenter/triton-go/v2/storage"
+)
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func buildStorageClient(t *testing.T) *storage.StorageClient {
+	t.Helper()
+
+	if os.Getenv("TRITON_TEST") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TRITON_TEST' set")
+	}
+
+	mantaURL := triton.GetEnv("MANTA_URL")
+	if mantaURL == "" {
+		t.Skip("TRITON_MANTA_URL or SDC_MANTA_URL must be set to run storage acceptance tests")
+	}
+
+	tritonURL := triton.GetEnv("URL")
+	tritonAccount := triton.GetEnv("ACCOUNT")
+	tritonKeyID := triton.GetEnv("KEY_ID")
+	tritonKeyMaterial := triton.GetEnv("KEY_MATERIAL")
+	userName := triton.GetEnv("USER")
+
+	if tritonAccount == "" {
+		t.Fatal("TRITON_ACCOUNT must be set")
+	}
+	if tritonKeyID == "" {
+		t.Fatal("TRITON_KEY_ID must be set")
+	}
+
+	var signer authentication.Signer
+	var err error
+	if tritonKeyMaterial != "" {
+		signer, err = authentication.NewPrivateKeySigner(authentication.PrivateKeySignerInput{
+			KeyID:              tritonKeyID,
+			PrivateKeyMaterial: []byte(tritonKeyMaterial),
+			AccountName:        tritonAccount,
+			Username:           userName,
+		})
+	} else {
+		signer, err = authentication.NewSSHAgentSigner(authentication.SSHAgentSignerInput{
+			KeyID:       tritonKeyID,
+			AccountName: tritonAccount,
+			Username:    userName,
+		})
+	}
+	if err != nil {
+		t.Fatalf("Error creating signer: %s", err)
+	}
+
+	client, err := storage.NewClient(&triton.ClientConfig{
+		TritonURL:   tritonURL,
+		MantaURL:    mantaURL,
+		AccountName: tritonAccount,
+		Username:    userName,
+		Signers:     []authentication.Signer{signer},
+	})
+	if err != nil {
+		t.Fatalf("Error creating storage client: %s", err)
+	}
+
+	return client
+}
+
+// TestAccStorageLifecycle exercises the full Manta object storage workflow:
+// directory creation, object upload, listing, retrieval, deletion semantics,
+// and recursive cleanup.
+func TestAccStorageLifecycle(t *testing.T) {
+	client := buildStorageClient(t)
+	ctx := context.Background()
+
+	testID := randomHex(16)
+	basePath := "/stor/" + testID
+	nestedPath := basePath + "/" + testID
+	objectContent := testID
+
+	// Always clean up, even on failure.
+	t.Cleanup(func() {
+		_ = client.Dir().Delete(ctx, &storage.DeleteDirectoryInput{
+			DirectoryName: basePath,
+			ForceDelete:   true,
+		})
+	})
+
+	// Step 1: Create nested directory structure.
+	t.Log("Step 1: Creating directories")
+	if err := client.Dir().Put(ctx, &storage.PutDirectoryInput{
+		DirectoryName: basePath,
+	}); err != nil {
+		t.Fatalf("Dir().Put(%s): %v", basePath, err)
+	}
+	if err := client.Dir().Put(ctx, &storage.PutDirectoryInput{
+		DirectoryName: nestedPath,
+	}); err != nil {
+		t.Fatalf("Dir().Put(%s): %v", nestedPath, err)
+	}
+
+	// Step 2: Upload objects.
+	t.Log("Step 2: Uploading objects")
+	if err := client.Objects().Put(ctx, &storage.PutObjectInput{
+		ObjectPath:  nestedPath + "/uuid.txt",
+		ContentType: "text/plain",
+		ObjectReader: strings.NewReader(objectContent),
+	}); err != nil {
+		t.Fatalf("Objects().Put(%s/uuid.txt): %v", nestedPath, err)
+	}
+	if err := client.Objects().Put(ctx, &storage.PutObjectInput{
+		ObjectPath:  basePath + "/uuid.txt",
+		ContentType: "text/plain",
+		ObjectReader: strings.NewReader(objectContent),
+	}); err != nil {
+		t.Fatalf("Objects().Put(%s/uuid.txt): %v", basePath, err)
+	}
+
+	// Step 3: List top-level directory.
+	t.Log("Step 3: Listing top-level directory")
+	topList, err := client.Dir().List(ctx, &storage.ListDirectoryInput{
+		DirectoryName: basePath,
+	})
+	if err != nil {
+		t.Fatalf("Dir().List(%s): %v", basePath, err)
+	}
+	foundDir := false
+	foundObj := false
+	for _, entry := range topList.Entries {
+		if entry.Name == testID && entry.Type == "directory" {
+			foundDir = true
+		}
+		if entry.Name == "uuid.txt" && entry.Type == "object" {
+			foundObj = true
+		}
+	}
+	if !foundDir {
+		t.Errorf("Expected directory entry %q in listing of %s, got: %+v",
+			testID, basePath, topList.Entries)
+	}
+	if !foundObj {
+		t.Errorf("Expected object entry \"uuid.txt\" in listing of %s, got: %+v",
+			basePath, topList.Entries)
+	}
+
+	// Step 4: List nested directory.
+	t.Log("Step 4: Listing nested directory")
+	nestedList, err := client.Dir().List(ctx, &storage.ListDirectoryInput{
+		DirectoryName: nestedPath,
+	})
+	if err != nil {
+		t.Fatalf("Dir().List(%s): %v", nestedPath, err)
+	}
+	foundNestedObj := false
+	for _, entry := range nestedList.Entries {
+		if entry.Name == "uuid.txt" && entry.Type == "object" {
+			foundNestedObj = true
+		}
+	}
+	if !foundNestedObj {
+		t.Errorf("Expected object entry \"uuid.txt\" in listing of %s, got: %+v",
+			nestedPath, nestedList.Entries)
+	}
+
+	// Step 5: Get and verify object contents.
+	t.Log("Step 5: Verifying object contents")
+	for _, objPath := range []string{
+		basePath + "/uuid.txt",
+		nestedPath + "/uuid.txt",
+	} {
+		output, err := client.Objects().Get(ctx, &storage.GetObjectInput{
+			ObjectPath: objPath,
+		})
+		if err != nil {
+			t.Fatalf("Objects().Get(%s): %v", objPath, err)
+		}
+		body, err := ioutil.ReadAll(output.ObjectReader)
+		output.ObjectReader.Close()
+		if err != nil {
+			t.Fatalf("reading body of %s: %v", objPath, err)
+		}
+		if string(body) != objectContent {
+			t.Errorf("Objects().Get(%s): expected body %q, got %q",
+				objPath, objectContent, string(body))
+		}
+	}
+
+	// Step 6: Delete non-empty nested directory (should fail).
+	t.Log("Step 6: Attempting to delete non-empty directory")
+	err = client.Dir().Delete(ctx, &storage.DeleteDirectoryInput{
+		DirectoryName: nestedPath,
+		ForceDelete:   false,
+	})
+	if err == nil {
+		t.Fatal("Expected error deleting non-empty directory, got nil")
+	}
+	if !terrors.IsDirectoryNotEmptyError(err) {
+		t.Fatalf("Expected DirectoryNotEmpty error, got: %v", err)
+	}
+
+	// Step 7: Delete nested object.
+	t.Log("Step 7: Deleting nested object")
+	if err := client.Objects().Delete(ctx, &storage.DeleteObjectInput{
+		ObjectPath: nestedPath + "/uuid.txt",
+	}); err != nil {
+		t.Fatalf("Objects().Delete(%s/uuid.txt): %v", nestedPath, err)
+	}
+
+	// Step 8: Delete now-empty nested directory (should succeed).
+	t.Log("Step 8: Deleting empty nested directory")
+	if err := client.Dir().Delete(ctx, &storage.DeleteDirectoryInput{
+		DirectoryName: nestedPath,
+		ForceDelete:   false,
+	}); err != nil {
+		t.Fatalf("Dir().Delete(%s): %v", nestedPath, err)
+	}
+
+	// Step 9: Verify nested directory is gone.
+	t.Log("Step 9: Verifying nested directory is gone")
+	_, err = client.Dir().List(ctx, &storage.ListDirectoryInput{
+		DirectoryName: nestedPath,
+	})
+	if err == nil {
+		t.Fatal("Expected error listing deleted directory, got nil")
+	}
+	if !terrors.IsResourceNotFoundError(err) && !terrors.IsDirectoryDoesNotExistError(err) &&
+		!terrors.IsStatusNotFoundCode(err) {
+		t.Fatalf("Expected ResourceNotFound or DirectoryDoesNotExist error, got: %v", err)
+	}
+
+	// Step 10: Recursive delete of remaining tree.
+	t.Log("Step 10: Recursive delete of remaining tree")
+	if err := client.Dir().Delete(ctx, &storage.DeleteDirectoryInput{
+		DirectoryName: basePath,
+		ForceDelete:   true,
+	}); err != nil {
+		t.Fatalf("Dir().Delete(%s, ForceDelete=true): %v", basePath, err)
+	}
+
+	// Step 11: Verify top-level directory is gone.
+	t.Log("Step 11: Verifying top-level directory is gone")
+	_, err = client.Dir().List(ctx, &storage.ListDirectoryInput{
+		DirectoryName: basePath,
+	})
+	if err == nil {
+		t.Fatal("Expected error listing deleted directory, got nil")
+	}
+	if !terrors.IsResourceNotFoundError(err) && !terrors.IsDirectoryDoesNotExistError(err) &&
+		!terrors.IsStatusNotFoundCode(err) {
+		fmt.Printf("Note: got error type %T: %v\n", err, err)
+	}
+}

--- a/testutils/steps.go
+++ b/testutils/steps.go
@@ -1,6 +1,7 @@
 //
 // Copyright 2020 Joyent, Inc.
 // Copyright 2025 MNX Cloud, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/testutils/steps.go
+++ b/testutils/steps.go
@@ -138,7 +138,7 @@ type StepGetImage struct {
 
 func (s *StepGetImage) Run(state TritonStateBag) StepAction {
 	const imageName = "ubuntu-24.04"
-	const imageVersion = "20240612"
+	const imageVersion = "20260121"
 
 	computeClient, err := compute.NewClient(state.Config())
 	if err != nil {
@@ -156,8 +156,8 @@ func (s *StepGetImage) Run(state TritonStateBag) StepAction {
 	}
 
 	if len(images) == 0 {
-		state.AppendError(pkgerrors.Errorf("No images matching image name %s",
-			imageName))
+		state.AppendError(pkgerrors.Errorf("No images matching image name %s v%s",
+			imageName, imageVersion))
 		return Halt
 	}
 

--- a/version.go
+++ b/version.go
@@ -24,7 +24,7 @@ const Version = "2.0.0"
 // If this is "" (empty string) then it means that it is a final release.
 // Otherwise, this is a pre-release such as "dev" (in development), "beta",
 // "rc1", etc.
-var Prerelease = "pre4"
+var Prerelease = "pre5"
 
 // UserAgent returns a Triton-go characteristic string that allows the
 // network protocol peers to identify the version, release and runtime

--- a/version.go
+++ b/version.go
@@ -1,5 +1,6 @@
 //
 // Copyright 2020 Joyent, Inc.
+// Copyright 2026 Edgecast Cloud LLC.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,6 +12,7 @@ package triton
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 )
 
 // Version represents main version number of the current release
@@ -40,3 +42,33 @@ func UserAgent() string {
 // CloudAPIMajorVersion specifies the CloudAPI version compatibility
 // for current release of the Triton-go SDK.
 const CloudAPIMajorVersion = "8"
+
+// VCSInfo contains version control metadata embedded by the Go toolchain
+// at build time.
+type VCSInfo struct {
+	Revision string
+	Time     string
+	Modified bool
+}
+
+// BuildInfo returns VCS metadata embedded by the Go toolchain. If the
+// binary was not built with module support or VCS info is unavailable,
+// the returned fields will be empty/false.
+func BuildInfo() VCSInfo {
+	var info VCSInfo
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
+	}
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			info.Revision = s.Value
+		case "vcs.time":
+			info.Time = s.Value
+		case "vcs.modified":
+			info.Modified = s.Value == "true"
+		}
+	}
+	return info
+}


### PR DESCRIPTION
While running tests and the examples, I encountered a few other bugs:

- [UpdateConfig](https://github.com/TritonDataCenter/sdc-cloudapi/blob/master/docs/index.md#updateconfig-put-loginconfig) should use PUT not POST
- #155 
-  #204
-  Cherry-picked the fix from: #205
- Manta examples should use `MANTA_` env vars
- Image tags can have booleans, strings, or numbers as values.

I also removed deprecated `govvv` and `dep` tools, go now natively supports what they offered.

I am very slightly concerned someone might be relying on the current deleteAll behavior, it is broken and will only delete the first object in a directory and stop, now it actually deletes all objects in the directory and all directories if ForceDelete is true (Just like `mrm -r`.) However, I'm also not sure how the current broken behavior would be at all useful so I might be overthinking it. That being said, I'm open to backing out that change and addressing it separately.

Testing notes on ticket.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>